### PR TITLE
owl2sparql conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ ones and finally render and print the last of them in description logics syntax.
 from owlapy.render import DLSyntaxObjectRenderer
 from owlapy.model import IRI, OWLClass, OWLObjectProperty, OWLObjectSomeValuesFrom, \
                          OWLObjectIntersectionOf
+from owlapy.owl2sparql.converter import owl_expression_to_sparql
 
 # Create an IRI object using the iri as a string for 'male' class.
 male_iri = IRI.create('http://example.com/society#male')
@@ -44,7 +45,7 @@ male_teachers_with_children = OWLObjectIntersectionOf([males_with_children, teac
 # You can render and print owl class expressions in description logics syntax
 print(DLSyntaxObjectRenderer().render(male_teachers_with_children)) 
 # (∃ hasChild.male) ⊓ teacher
-print(Owl2SparqlConverter().as_query("?x", male_teachers_with_children))
+print(owl_expression_to_sparql("?x", male_teachers_with_children))
 #  SELECT DISTINCT ?x WHERE {  ?x <http://example.com/society#hasChild> ?s_1 . ?s_1 a <http://example.com/society#male> . ?x a <http://example.com/society#teacher> .  } }
 ```
 For more, you can check the [API documentation](https://ontolearn-docs-dice-group.netlify.app/autoapi/owlapy/#module-owlapy).

--- a/owlapy/owl2sparql/converter.py
+++ b/owlapy/owl2sparql/converter.py
@@ -495,7 +495,7 @@ class Owl2SparqlConverter:
                 self.append(",")
             assert isinstance(ind, OWLNamedIndividual)
             self.append(f"<{ind.to_string_id()}>")
-        self.append(f" )")
+        self.append(f" ) )")
 
     @process.register
     def _(self, ce: OWLDataSomeValuesFrom):
@@ -626,3 +626,14 @@ class Owl2SparqlConverter:
         query = "\n".join(qs)
         parseQuery(query)
         return query
+
+
+converter = Owl2SparqlConverter()
+
+
+def owl_expression_to_sparql(root_variable: str,
+                             ce: OWLClassExpression,
+                             count: bool = False,
+                             values: Optional[Iterable[OWLNamedIndividual]] = None,
+                             named_individuals: bool = False):
+    return converter.as_query(root_variable, ce, count, values, named_individuals)


### PR DESCRIPTION
Fixed bug related with conversion of `OWLObjectOneOf` and added method `owl_expression_to_sparql`.