### PR TITLE
Documentation update + __version__ increase

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,5 +14,5 @@ Welcome to OWLAPY!
    usage/usage_examples
    usage/ontologies
    usage/reasoner
-   usage/reasoner_details
+   usage/reasoning_details
    autoapi/owlapy/index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,4 +12,7 @@ Welcome to OWLAPY!
 
    usage/main
    usage/usage_examples
+   usage/ontologies
+   usage/reasoner
+   usage/reasoner_details
    autoapi/owlapy/index

--- a/docs/usage/main.md
+++ b/docs/usage/main.md
@@ -1,6 +1,6 @@
 # About owlapy
 
-**Version:** owlapy 1.0.2
+**Version:** owlapy 1.1.0
 
 **GitHub repository:** [https://github.com/dice-group/owlapy](https://github.com/dice-group/owlapy)
 

--- a/docs/usage/ontologies.md
+++ b/docs/usage/ontologies.md
@@ -1,0 +1,219 @@
+# Ontologies
+To get started with Structured Machine Learning, the first thing
+required is an [Ontology](https://www.w3.org/TR/owl2-overview/) with
+[Named Individuals](https://www.w3.org/TR/owl-syntax/#Named_Individuals).
+In this guide we show the basics of working with ontologies in Owlapy.
+We will use the _father_ ontology for the following examples. 
+
+## Loading an Ontology
+
+To load an ontology as well as to manage it, you will need an 
+[OWLOntologyManager](owlapy.owl_ontology_manager.OWLOntologyManager)
+An ontology can be loaded using the following Python code:
+
+```python
+from owlapy.iri import IRI
+from owlapy.owl_ontology_manager import OntologyManager
+
+manager = OntologyManager()
+onto = manager.load_ontology(IRI.create("file://KGs/Family/father.owl"))
+```
+
+First, we import the `IRI` class and a suitable OWLOntologyManager. To
+load a file from our computer, we have to reference it with an
+[IRI](owlapy.iri.IRI). Secondly, we need the
+Ontology Manager. Owlapy contains one such manager: The
+[OntologyManager](owlapy.owl_ontology_manager.OntologyManager).
+
+Now, we can already inspect the contents of the ontology. For example,
+to list all individuals:
+
+<!--pytest-codeblocks:cont-->
+```python
+for ind in onto.individuals_in_signature():
+    print(ind)
+```
+
+You can get the object properties in the signature:
+
+<!--pytest-codeblocks:cont-->
+```python
+onto.object_properties_in_signature()
+```
+
+For more methods, see the abstract class [OWLOntology](owlapy.owl_ontology.Ontology)
+or the concrete implementation [Ontology](owlapy.owl_ontology.Ontology).
+
+## Modifying an Ontology
+
+Axioms in ontology serve as the basis for defining the vocabulary of a domain and for 
+making statements about the relationships between individuals and concepts in that domain.
+They provide a formal and precise way to represent knowledge and allow for automated 
+reasoning and inference. Axioms can be **added**, **modified**, or **removed** from an ontology, 
+allowing the ontology to evolve and adapt as new knowledge is gained.
+
+In owlapy we also have different axioms represented by different classes. You can check all
+the axioms classes [here](owlapy.owl_axioms). Some frequently used axioms are:
+
+- [OWLDeclarationAxiom](owlapy.owl_axiom.OWLDeclarationAxiom)
+- [OWLObjectPropertyAssertionAxiom](owlapy.owl_axiom.OWLObjectPropertyAssertionAxiom)
+- [OWLDataPropertyAssertionAxiom](owlapy.owl_axiom.OWLDataPropertyAssertionAxiom)
+- [OWLClassAssertionAxiom](owlapy.owl_axiom.OWLClassAssertionAxiom)
+- [OWLSubClassOfAxiom](owlapy.owl_axiom.OWLSubClassOfAxiom)
+- [OWLEquivalentClassesAxiom](owlapy.owl_axiom.OWLEquivalentClassesAxiom)
+
+
+#### Add a new Class
+
+Let's suppose you want to add a new class in our example ontology `KGs/Family/father.owl` 
+It can be done as follows:
+
+<!--pytest-codeblocks:cont-->
+
+```python
+from owlapy.class_expression import OWLClass
+from owlapy.owl_axiom import OWLDeclarationAxiom
+
+iri = IRI('http://example.com/father#', 'child')
+child_class = OWLClass(iri)
+child_class_declaration_axiom = OWLDeclarationAxiom(child_class)
+
+manager.add_axiom(onto, child_class_declaration_axiom)
+```
+In this example, we added the class 'child' to the _father.owl_ ontology.
+Firstly we create an instance of [OWLClass](owlapy.class_expression.owl_class.OWLClass) to represent the concept 
+of 'child' by using an [IRI](owlapy.iri.IRI). 
+On the other side, an instance of `IRI` is created by passing two arguments which are
+the namespace of the ontology and the remainder 'child'. To declare this new class we need
+an axiom of type `OWLDeclarationAxiom`. We simply pass the `child_class` to create an 
+instance of this axiom. The final step is to add this axiom to the ontology using the 
+[OWLOntologyManager](owlapy.owl_ontology_manager.OWLOntologyManager). We use the `add_axiom` method
+of the `manager` to add into the ontology
+`onto` the axiom `child_class_declaration_axiom`.
+
+#### Add a new Object Property / Data Property
+
+The idea is the same as adding a new class. Instead of `OWLClass`, for object properties,
+you can use the class [OWLObjectProperty](owlapy.owl_property.OWLObjectProperty) and for data
+properties you can use the class [OWLDataProperty](owlapy.owl_property.OWLDataProperty).
+
+<!--pytest-codeblocks:cont-->
+
+```python
+from owlapy.owl_property import OWLObjectProperty, OWLDataProperty
+
+# adding the object property 'hasParent'
+hasParent_op = OWLObjectProperty(IRI('http://example.com/father#', 'hasParent'))
+hasParent_op_declaration_axiom = OWLDeclarationAxiom(hasParent_op)
+manager.add_axiom(onto, hasParent_op_declaration_axiom)
+
+# adding the data property 'hasAge' 
+hasAge_dp = OWLDataProperty(IRI('http://example.com/father#', 'hasAge'))
+hasAge_dp_declaration_axiom = OWLDeclarationAxiom(hasAge_dp)
+manager.add_axiom(onto, hasAge_dp_declaration_axiom)
+```
+
+See the [owlapy](owlapy) for more OWL entities that you can add as a declaration axiom.
+
+#### Add an Assertion Axiom
+
+To assign a class to a specific individual use the following code:
+
+<!--pytest-codeblocks:cont-->
+
+```python
+from owlapy.owl_axiom import OWLClassAssertionAxiom
+
+individuals = list(onto.individuals_in_signature())
+heinz = individuals[1]  # get the 2nd individual in the list which is 'heinz'
+
+class_assertion_axiom = OWLClassAssertionAxiom(heinz, child_class)
+
+manager.add_axiom(onto, class_assertion_axiom)
+```
+We have used the previous method `individuals_in_signature()` to get all the individuals 
+and converted them to a list, so we can access them by using indexes. In this example, we
+want to assert a class axiom for the individual `heinz`. 
+We have used the class `OWLClassAssertionAxiom`
+where the first argument is the 'individual' `heinz` and the second argument is 
+the 'class_expression'. As the class expression, we used the previously defined class 
+`child_Class`. Finally, add the axiom by using `add_axiom` method of the [OWLOntologyManager](owlapy.owl_ontology_manager.OWLOntologyManager).
+
+Let's show one more example using a `OWLDataPropertyAssertionAxiom` to assign the age of 17 to
+heinz. 
+
+<!--pytest-codeblocks:cont-->
+
+```python
+from owlapy.owl_literal import OWLLiteral
+from owlapy.owl_axiom import OWLDataPropertyAssertionAxiom
+
+literal_17 = OWLLiteral(17)
+dp_assertion_axiom = OWLDataPropertyAssertionAxiom(heinz, hasAge_dp, literal_17)
+
+manager.add_axiom(onto, dp_assertion_axiom)
+```
+
+[OWLLiteral](owlapy.owl_literal.OWLLiteral) is a class that represents the literal values in
+Owlapy. We have stored the integer literal value of '18' in the variable `literal_17`.
+Then we construct the `OWLDataPropertyAssertionAxiom` by passing as the first argument, the 
+individual `heinz`, as the second argument the data property `hasAge_dp`, and the third 
+argument the literal value `literal_17`. Finally, add it to the ontology by using `add_axiom` 
+method.
+
+Check the [owlapy](owlapy) to see all the OWL 
+assertion axioms that you can use.
+
+
+#### Remove an Axiom
+
+To remove an axiom you can use the `remove_axiom` method of the ontology manager as follows:
+
+<!--pytest-codeblocks:cont-->
+```python
+manager.remove_axiom(onto,dp_assertion_axiom)
+```
+The first argument is the ontology you want to remove the axiom from and the second 
+argument is the axiom you want to remove.
+
+
+## Save an Ontology
+
+If you modified an ontology, you may want to save it as a new file. To do this
+you can use the `save_ontology` method of the [OWLOntologyManager](owlapy.owl_ontology_manager.OWLOntologyManager).
+It requires two arguments, the first is the ontology you want to save and The second
+is the IRI of the new ontology.
+
+<!--pytest-codeblocks:cont-->
+```python
+manager.save_ontology(onto, IRI.create('file:/' + 'test' + '.owl'))
+```
+ The above line of code will save the ontology `onto` in the file *test.owl* which will be
+created in the same directory as the file you are running this code.
+
+
+## Worlds
+
+Owlready2 stores every triple in a ‘World’ object, and it can handle several Worlds in parallel.
+Owlready2 uses an optimized quadstore to store the world. Each world object is stored in a separate quadstore and 
+by default the quadstore is stored in memory,
+but it can also be stored in an SQLite3 file. The method `save_world()` of the ontology manager does the latter.
+When an _OWLOntologyManager_ object is created, a new world is also created as an attribute of the manager.
+By calling the method `load_ontology(iri)` the ontology is loaded to this world. 
+
+It possible to create several isolated “worlds”, sometimes
+called “universe of speech”. This makes it possible in particular to load
+the same ontology several times, independently, that is to say, without
+the modifications made on one copy affecting the other copy. Sometimes the need to [isolate an ontology](reasoning_details.md#isolated-world) 
+arise. What that means is that you can have multiple reference of the same ontology in different
+worlds.
+
+-------------------------------------------------------------------------------------
+
+It is important that an ontology is associated with a reasoner which is used to inferring knowledge 
+from the ontology, i.e. to perform ontology reasoning.
+In the next guide we will see how to use a reasoner in Owlapy. 
+
+
+
+

--- a/docs/usage/reasoner.md
+++ b/docs/usage/reasoner.md
@@ -1,0 +1,231 @@
+# Reasoners
+
+To validate facts about statements in the ontology, the help of a reasoner
+component is required.
+
+For this guide we will also consider the 'father' ontology that we slightly described [here](ontologies.md):
+
+```python
+from owlapy.owl_ontology_manager import OntologyManager
+
+manager = OntologyManager()
+onto = manager.load_ontology(IRI.create("KGs/Family/father.owl"))
+```
+
+In our Owlapy library, we provide several **reasoners** to choose
+from. Currently, there are the following reasoners available: 
+
+- [**OntologyReasoner**](owlapy.owl_reasoner.OntologyReasoner)
+
+    Or differently Structural Reasoner, is the base reasoner in Owlapy. The functionalities
+  of this reasoner are limited. It does not provide full reasoning in _ALCH_. Furthermore,
+  it has no support for instances of complex class expressions, which is covered by the
+  other reasoners (SyncReasoner and FIC). We recommend to use the other reasoners for any heavy reasoning tasks.
+
+    **Initialization:**
+
+   ```python
+   from owlapy.owl_reasoner import OntologyReasoner
+   
+   structural_reasoner = OntologyReasoner(onto)
+   ```
+
+    The structural reasoner requires an ontology ([OWLOntology](owlapy.owl_ontology.OWLOntology)).
+  The second argument is `isolate` argument which isolates the world (therefore the ontology) where the reasoner is
+  performing the reasoning. More on that on _[Reasoning Details](reasoning_details.md#isolated-world)_.
+    
+
+
+- [**SyncReasoner**](owlapy.owl_reasoner.SyncReasoner)
+
+    Can perform full reasoning in _ALCH_ due to the use of HermiT/Pellet and provides support for
+  complex class expression instances (when using the method `instances`). SyncReasoner is more useful when
+  your main goal is reasoning over the ontology.
+
+    **Initialization:**
+
+    ```python
+    from owlapy.owl_reasoner import SyncReasoner, BaseReasoner
+    
+    sync_reasoner = SyncReasoner(onto, BaseReasoner.HERMIT, infer_property_values = True)
+    ```
+    
+    Sync Reasoner requires an ontology and a base reasoner of type [BaseReasoner](owlapy.owl_reasoner.BaseReasoner)
+    which is just an enumeration with two possible values: `BaseReasoner.HERMIT` and `BaseReasoner.PELLET`.
+  You can set the `infer_property_values` argument to `True` if you want the reasoner to infer
+  property values. `infer_data_property_values` is an additional argument when the base reasoner is set to 
+    `BaseReasoner.PELLET`. The argument `isolated` is inherited from the base class
+
+
+- [**FastInstanceCheckerReasoner**](owlapy.owl_reasoner.FastInstanceCheckerReasoner) **(FIC)**
+
+    FIC also provides support for complex class expression but the rest of the methods are the same as in
+  the base reasoner.
+  It has a cache storing system that allows for faster execution of some reasoning functionalities. Due to this
+  feature, FIC is more appropriate to be used in concept learning.
+
+    **Initialization:**
+
+    ```python
+    from owlapy.owl_reasoner import FastInstanceCheckerReasoner
+    
+    fic_reasoner = FastInstanceCheckerReasoner(onto, structural_reasoner, property_cache = True,
+                                                   negation_default = True, sub_properties = False)
+    ```
+    Besides the ontology, FIC requires a base reasoner to delegate any reasoning tasks not covered by it.
+  This base reasoner
+  can be any other reasoner in Owlapy. `property_cache` specifies whether to cache property values. This
+  requires more memory, but it speeds up the reasoning processes. If `negation_default` argument is set
+  to `True` the missing facts in the ontology means false. The argument
+    `sub_properties` is another boolean argument to specify whether you want to take sub properties in consideration
+  for `instances()` method.
+
+## Usage of the Reasoner
+All the reasoners available in the Owlapy library inherit from the
+class: [OWLReasonerEx](owlapy.owl_reasoner.OWLReasonerEx). This class provides some 
+extra convenient methods compared to its base class [OWLReasoner](owlapy.owl_reasoner.OWLReasoner), which is an 
+abstract class.
+Further on, in this guide, we use 
+[SyncReasoner](owlapy.owl_reasoner.SyncReasoner).
+to show the capabilities of a reasoner in Owlapy.
+
+To give examples we consider the _father_ dataset. 
+If you are not already familiar with this small dataset,
+you can find an overview of it [here](ontologies.md).
+
+
+## Class Reasoning
+
+Using an [OWLOntology](owlapy.owl_ontology.OWLOntology) you can list all the classes in the signature, 
+but a reasoner can give you more than that. You can get the subclasses, superclasses or the 
+equivalent classes of a class in the ontology:
+
+<!--pytest-codeblocks:cont-->
+
+```python
+from owlapy.class_expression import OWLClass
+from owlapy.iri import IRI
+
+namespace = "http://example.com/father#"
+male = OWLClass(IRI(namespace, "male"))
+
+male_super_classes = sync_reasoner.super_classes(male)
+male_sub_classes = sync_reasoner.sub_classes(male)
+male_equivalent_classes = sync_reasoner.equivalent_classes(male)
+```
+
+We define the _male_ class by creating an [OWLClass](owlapy.class_expression.owl_class.OWLClass) object. The 
+methods `super_classes` and `sub_classes` have 2 more boolean arguments: `direct` and `only_named`. 
+If `direct=True` then only the direct classes in the 
+hierarchy will be returned, else it will return every class in the hierarchy depending 
+on the method(sub_classes or super_classes).
+By default, its value is _False_. 
+The next argument `only_named` specifies whether you want
+to show only named classes or complex classes as well. By default, its value is _True_ which 
+means that it will return only the named classes.
+
+>**NOTE**: The extra arguments `direct` and `only_named` are also used in other methods that reason
+upon the class, object property, or data property hierarchy.
+
+You can get all the types of a certain individual using `types` method:
+
+<!--pytest-codeblocks:cont-->
+
+```python
+anna = list(onto.individuals_in_signature()).pop()
+
+anna_types = sync_reasoner.types(anna)
+```
+
+We retrieve _anna_ as the first individual on the list of individuals 
+of the 'Father' ontology. The `type` method only returns named classes.
+
+
+## Object Properties and Data Properties Reasoning
+Owlapy reasoners offers some convenient methods for working with object properties and 
+data properties. Below we show some of them, but you can always check all the methods in the 
+[SyncReasoner](owlapy.owl_reasoner.SyncReasoner)
+class documentation. 
+
+You can get all the object properties that an individual has by using the 
+following method:
+
+<!--pytest-codeblocks:cont-->
+```python
+anna = individuals[0] 
+object_properties = sync_reasoner.ind_object_properties(anna)
+```
+In this example, `object_properties` contains all the object properties
+that _anna_ has, which in our case would only be _hasChild_.
+Now we can get the individuals of this object property for _anna_.
+
+<!--pytest-codeblocks:cont-->
+```python
+for op in object_properties:
+    object_properties_values = sync_reasoner.object_property_values(anna, op)
+    for individual in object_properties_values:
+        print(individual)
+```
+
+In this example we iterated over the `object_properties`, assuming that there
+are more than 1, and we use the reasoner
+to get the values for each object property `op` of the individual `anna`. The values 
+are individuals which we store in the variable `object_properties_values` and are 
+printed in the end. The method `object_property_values` requires as the
+first argument, an [OWLNamedIndividual](owlapy.owl_individual.OWLNamedIndividual) that is the subject of the object property values and 
+the second argument an [OWLObjectProperty](owlapy.owl_property.OWLObjectProperty) whose values are to be retrieved for the 
+specified individual.  
+
+> **NOTE:** You can as well get all the data properties of an individual in the same way by using 
+`ind_data_properties` instead of `ind_object_properties` and `data_property_values` instead of 
+`object_property_values`. Keep in mind that `data_property_values` returns literal values 
+(type of [OWLLiteral](owlapy.owl_literal.OWLLiteral)).
+
+In the same way as with classes, you can also get the sub object properties or equivalent object properties.
+
+<!--pytest-codeblocks:cont-->
+
+```python
+from owlapy.owl_property import OWLObjectProperty
+
+hasChild = OWLObjectProperty(IRI(namespace, "hasChild"))
+
+equivalent_to_hasChild = sync_reasoner.equivalent_object_properties(hasChild)
+hasChild_sub_properties = sync_reasoner.sub_object_properties(hasChild)
+```
+
+In case you want to get the domains and ranges of an object property use the following:
+
+<!--pytest-codeblocks:cont-->
+```python
+hasChild_domains = sync_reasoner.object_property_domains(hasChild)
+hasChild_ranges = sync_reasoner.object_property_ranges(hasChild)
+```
+
+> **NOTE:** Again, you can do the same for data properties but instead of the word 'object' in the 
+> method name you should use 'data'.
+
+
+## Find Instances
+
+The method `instances` is a very convenient method. It takes only 1 argument that is basically
+a class expression and returns all the individuals belonging to that class expression. In Owlapy 
+we have implemented a Python class for each type of class expression.
+The argument is of type [OWLClassExpression](owlapy.class_expression.class_expression.OWLClassExpression).
+
+Let us now show a simple example by finding the instances of the class _male_ and printing them:
+
+<!--pytest-codeblocks:cont-->
+```python
+male_individuals = sync_reasoner.instances(male)
+for ind in male_individuals:
+    print(ind)
+```
+
+-----------------------------------------------------------------------
+
+In this guide we covered the main functionalities of the reasoners in Owlapy. More
+details are provided in the next guide.
+
+
+

--- a/docs/usage/reasoning_details.md
+++ b/docs/usage/reasoning_details.md
@@ -1,0 +1,243 @@
+# Reasoning Details
+
+In the previous guide we explained how to [use reasoners](reasoner.md) in Owlapy. Here we cover a detailed explanation of 
+the Owlapy reasoners, particularly [SyncReasoner](owlapy.owl_reasoner.SyncReasoner).
+Before we continue to talk about its [capabilities](#capabilities) we have to explain briefly 
+the term _sync_reasoner_.
+
+## Sync Reasoner
+
+_sync_reasoner_ is a definition used in owlready2 to run [HermiT](http://www.hermit-reasoner.com/) 
+or [Pellet](https://github.com/stardog-union/pellet) and
+automatically apply the facts deduced to the quadstore. In simple terms, by running HermiT or Pellet,
+one can infer more knowledge from the ontology (the specification are not mentioned here). 
+We make use of this functionality in Owlapy, and it is represented by SyncReasoner. 
+We explained the concept of "Worlds" in [Working with Ontologies](ontologies.md#worlds). Having 
+that in mind you need to know that sync_reasoner is applied to the World object.
+After this particular reasoner is instantiated, because the facts are applied to the quadstore, changes made
+in the ontology by using the ontology manager will not be reflected to the ontology. The reasoner will use the state of
+the ontology at the moment it is instantiated.
+
+There are 2 boolean parameters for sync_reasoner that you can specify when creating an instance of 
+[SyncReasoner](owlapy.owl_reasoner.SyncReasoner).
+The first one `infer_property_values` tells HermiT or Pellet whether to infer (or not) property values. The same idea but
+for data properties is specified by the parameter `infer_data_property_values` which is only relevant to Pellet.
+
+> Note: HermiT and Pellet are Java programs, so you will need to install
+a Java virtual machine to use them. If you don’t have Java, you may install
+it from www.java.com (for Windows and macOS) or from the packages
+of your Linux distribution (the packages are often named “jre” or “jdk” for
+Java Runtime Environment and Java Development Kit).
+
+## Isolated World
+
+In [_Working with Ontologies_](ontologies.md#worlds) we mentioned that we can have multiple reference of in different
+worlds, which we can use to isolate an ontology to a specific World. For simplicity the terms "isolated world" and 
+"isolated ontology" can be used interchangeably in this guide.
+The isolation comes in handy when we use multiple reasoners in the same script. If we create
+an instance of _SyncReasoner_ it will apply sync_reasoner in the world object
+of the ontology and this will affect also the other reasoner/s which is/are using the same world. 
+To overcome this issue you can set the argument `isolate=True` when
+initializing a reasoner.
+[FastInstanceCheckerReasoner](owlapy.owl_reasoner.FastInstanceCheckerReasoner) (FIC)
+does not have this argument because it uses a base reasoner to delegate most of its methods. Therefore,
+if the base reasoner has `isolate=True` then FIC will also operate in the isolated world of it's base reasoner.
+
+### Modifying an isolated ontology
+
+When a reasoner is operating in an isolated ontology, every axiom added to the original ontology before or after 
+the initialization, will not be reflected to the isolated ontology. To update the isolated ontology and add
+or remove any axiom, you can use `update_isolated_ontology(axioms_to_add, axioms_to_remove)`. This method accepts
+a list of axioms for every argument (i.e. the axioms that you want to add and the axioms that you want to remove).
+
+## Capabilities
+
+_SyncReasoner_ provides full reasoning in 
+_ALCH_. We have adapted and build upon 
+[owlready2](https://owlready2.readthedocs.io/en/latest/) reasoner to provide 
+our own implementation in python. Below we give more details about each
+functionality of our reasoner:
+
+
+- #### Sub and Super Classes
+
+    You can retrieve sub (super) classes of a given class expression. Depending on
+    your preferences you can retrieve the whole chain of sub (super) classes or only the
+    direct sub (super) classes (`direct` argument). It is also possible to get anonymous classes in addition
+    to named classes (`only_named` argument). Class equivalence entails subsumption of classes to each other.
+
+- #### Equivalent Classes
+
+    You are able to get the equivalent classes of a given class expression. It can be 
+    decided whether only named classes should be returned 
+    or anonymous classes as well. If two classes are subclasses of each other they
+    are considered equivalent.
+
+- #### Disjoint Classes
+
+    Every class that is explicitly defined as disjoint with another class will be returned.
+    In addition, every subclass and equivalent class of the disjoint classes will be
+    returned. If a target class does not have explicitly-defined disjoint classes the search
+    is transferred to the superclasses of that target class.
+
+- #### Equivalent Properties
+
+    You are able to get equivalent properties of a given object or data property.
+    If two properties are sub-properties of each other, they are considered equivalent.
+
+- #### Sub and Super Properties
+
+    Our reasoner has support also for sub and super properties of a 
+    given property. You can set the `direct` argument like in sub (super) classes.
+    Properties equivalence entails subsumption of properties to each other.
+
+- #### Disjoint Properties
+
+    Similarly to disjoint classes, you can get the disjoint properties of a property.
+    Same rules apply.
+
+- #### Property values
+
+    Given an individual(instance) and an object property you can get all the object values.
+    Similarly, given an individual and a data property you can get all the literal values.
+    You can set whether you want only the direct values or all of them.
+
+- #### Property domain and range
+
+    Easily retrieval available for domain and range for object properties and domain for data properties.
+
+- #### Instances
+
+    This functionality enables you to get instances for a given named(atomic) class or complex class expression.
+    For the moment direct instances of complex class expressions is not possible.
+
+- #### Types
+
+    This functionality enables you to get the types of a given instance. It returns only
+    named(atomic) classes. You can set the `direct` attribute.
+
+- #### Same and Different Individuals
+
+    Given an individual you can get the individuals that are explicitly defined as same or different to that individual.
+
+
+## Concrete Example
+
+You can find the associated [code](https://github.com/dice-group/owlapy/blob/develop/examples/ontology_reasoning.py) 
+for the following examples inside `examples/example_reasoner`
+(note that the naming of the classes/relations/individuals may change from the table below). 
+We constructed an ontology for testing purposes. On the table we show for
+each **method** of the reasoner _SyncReasoner_ the results
+depending on a given **TBox** and **Abox**. The level of complexity of the TBox-es is low compared
+to real world scenarios, but it's just to show the capabilities of the reasoner.
+
+> **Note:** not every method of the reasoner is used in this example. You can check all the methods at the 
+> [API documentation](owlapy.owl_reasoner).
+
+
+| Method                                    | TBox                      | ABox                  | Returns<br>(T = Thing) |
+|-------------------------------------------|---------------------------| --------------------- |------------------------|
+| Equivalent_classes(A)                     | A ≡ B                     | \-                    | [B]                    |
+| Equivalent_classes(B)                     | A ≡ B                     | \-                    | [A]                    |
+| Instances(A)                              | A ≡ B                     | A(a),B(b)             | [a,b]                  |
+| Instances(B)                              | A ≡ B                     | A(a),B(b)             | [a,b]                  |
+| Types(a)                                  | A ≡ B                     | A(a),B(b)             | [T, A,B]               |
+| Types(b)                                  | A ≡ B                     | A(a),B(b)             | [T, A,B]               |
+| Sub_classes(A)                            | A ≡ B                     | \-                    | [B]                    |
+| Sub_classes(B)                            | A ≡ B                     | \-                    | [A]                    |
+| Super_classes(A)                          | A ≡ B                     | \-                    | [B,T]                  |
+| Super_classes(B)                          | A ≡ B                     | \-                    | [A,T]                  |
+| Equivalent_object_properties(r1)          | r1 ≡ r2                   | \-                    | [r2]                   |
+| Equivalent_object_properties(r2)          | r1 ≡ r2                   | \-                    | [r1]                   |
+| sub_object_properties(r1)                 | r1 ≡ r2                   | \-                    | [r2]                   |
+| sub_object_properties(r2)                 | r1 ≡ r2                   | \-                    | [r1]                   |
+| object_property_values(a, r1, direct=False) | r1 ≡ r2                   | r1(a,b) r2(a,c)       | [c]                    |
+| object_property_values(a, r2, direct=False) | r1 ≡ r2                   | r1(a,b) r2(a,c)       | [c]                    |
+| Sub_classes(B)                            | A ⊑ B                     | \-                    | [A]                    |
+| Super_classes(A)                          | A ⊑ B                     | \-                    | [T, B]                 |
+| Types(a)                                  | A ⊑ B                     | A(a),B(b)             | [A,B,T]                |
+| Types(b)                                  | A ⊑ B                     | A(a),B(b)             | [B,T]                  |
+| Instances(A)                              | A ⊑ B                     | A(a),B(b)             | [a]                    |
+| Instances(B)                              | A ⊑ B                     | A(a),B(b)             | [a,b]                  |
+| sub_object_properties(r1)                 | r2 ⊑ r1                   | \-                    | [r2]                   |
+| object_property_values(a, r2)             | r2 ⊑ r1                   | r2(a,b)               | [b]                    |
+| object_property_values(a, r1, direct=False) | r2 ⊑ r1                   | r2(a,b)               | [b]                    |
+| Sub_classes(r1.T)                         | r2 ⊑ r1                   | \-                    | [r2.T]                 |
+| Super_classes(D, only_named=False)        | D ⊑ ∃r.E                  | \-                    | [T, ∃r.E]               |
+| Sub_classes(∃r.E)                          | D ⊑ ∃r.E                  | \-                    | [D]                    |
+| Instances(D)                              | D ⊑ ∃r.E                  | D(d) r(i,e) E(e)      | [d]                    |
+| Instances(∃r.E)                            | D ⊑ ∃r.E                  | D(d) r(i,e) E(e)      | [i, d]                 |
+| types(d)                                  | D ⊑ ∃r.E                  | D(d) r(i,e) E(e)      | [D,T]                  |
+| types(i)                                  | D ⊑ ∃r.E                  | D(d) r(i,e) E(e)      | [T]                    |
+| object_property_values(i, r)              | D ⊑ ∃r.E                  | r(i,e) E(e)           | [e]                    |
+| Sub_classes(D, only_named=False)          | ∃r.E ⊑ D                  | \-                    | [ ∃r.E]                 |
+| Super_classes( ∃r.E)                       | ∃r.E ⊑ D                  | \-                    | [D, T]                 |
+| Instances(D)                              | ∃r.E ⊑ D                  | D(d) r(i,e) E(e)      | [i, d]                 |
+| Instances(∃r.E)                            | ∃r.E ⊑ D                  | D(d) r(i,e) E(e)      | [i]                    |
+| types(d)                                  | ∃r.E ⊑ D                  | D(d) r(i,e) E(e)      | [D, T]                 |
+| types(i)                                  | ∃r.E ⊑ D                  | D(d) r(i,e) E(e)      | [D, T]                 |
+| object_property_values(i, r)              | ∃r.E ⊑ D                  | r(i,e) E(e)           | [e]                    |
+| Sub_classes(A)                            | A ⊑ B, B ⊑ A              | \-                    | [A,B]                  |
+| Sub_classes(B)                            | A ⊑ B, B ⊑ A              | \-                    | [A,B]                  |
+| Super_classes(A)                          | A ⊑ B, B ⊑ A              | \-                    | [T, B]                 |
+| Super_classes(B)                          | A ⊑ B, B ⊑ A              | \-                    | [T, A]                 |
+| Types(a)                                  | A ⊑ B, B ⊑ A              | A(a),B(b)             | [A,B,T]                |
+| Types(b)                                  | A ⊑ B, B ⊑ A              | A(a),B(b)             | [A,B,T]                |
+| Instances(A)                              | A ⊑ B, B ⊑ A              | A(a),B(b)             | [a,b]                  |
+| Instances(B)                              | A ⊑ B, B ⊑ A              | A(a),B(b)             | [a,b]                  |
+| Equivalent_classes(A,only_named=False)    | A ⊑ B, B ⊑ A              | \-                    | [B]                    |
+| Equivalent_classes(B,only_named=False)    | A ⊑ B, B ⊑ A              | \-                    | [A]                    |
+| sub_object_properties(r1)                 | r2⊑ r1, r1⊑ r2            | \-                    | [r2,r1]                |
+| sub_object_properties(r2)                 | r2⊑ r1, r1⊑ r2            | \-                    | [r1,r2]                |
+| Equivalent_object_properties(r1)          | r2⊑ r1, r1⊑ r2            | \-                    | [r2]                   |
+| Equivalent_object_properties(r2)          | r2⊑ r1, r1⊑ r2            | \-                    | [r1]                   |
+| object_property_values(a, r1, direct=False) | r2 ⊑ r1, r1 ⊑ r2          | r1(a,b) r2(a,c)       | [b,c]                  |
+| object_property_values(a, r2, direct=False) | r2 ⊑ r1, r1 ⊑ r2          | r1(a,b) r2(a,c)       | [b,c]                  |
+| Sub_classes(J ⊓ K)                        | I ⊑ J ⊓ K                 | \-                    | [I]                    |
+| Super_classes(I, only_named=False)        | I ⊑ J ⊓ K                 | \-                    | [J ⊓ K, J, K, T]       |
+| Instances(J ⊓ K)                          | I ⊑ J ⊓ K                 | I(c)                  | [c]                    |
+| types(c)                                  | I ⊑ J ⊓ K                 | I(c)                  | [J, K, I, T]           |
+| Super_classes(J ⊓ K)                      | J ⊓ K ⊑ I                 | \-                    | [I, T]                 |
+| Sub_classes(I, only_named=False)          | J ⊓ K ⊑ I                 | \-                    | [J ⊓ K]                |
+| Instances(I)                              | J ⊓ K ⊑ I                 | J(s),K(s)             | [s]                    |
+| Instances(J ⊓ K)                          | J ⊓ K ⊑ I                 | J(s),K(s)             | [s]                    |
+| types(s)                                  | J ⊓ K ⊑ I                 | J(s),K(s)             | [J, K, I, T]           |
+| Sub_classes( ∃r.E ⊓ B )                    | D ⊑ ∃r.E ⊓ B              | \-                    | [D]                    |
+| Super_classes(D, only_named=False)        | D ⊑ ∃r.E ⊓ B              | \-                    | [T, ∃r.E ⊓ B, B]        |
+| Instances(∃r.E ⊓ B)                        | D ⊑ ∃r.E ⊓ B              | D(d) r(b,f) E(f) B(b) | [d,b]                  |
+| Sub_classes(H, only_named= False)         | F ≡ ∃r.G, F ⊑ H           | \-                    | [F, ∃r.G]               |
+| Super_classes(F)                          | F ≡ ∃r.G, F ⊑ H           | \-                    | [H,∃r.G,T]              |
+| Super_classes(∃r.G)                        | F ≡ ∃r.G, F ⊑ H           | \-                    | [F,H,T]                |
+| Equivalent_classes(F, only_named=False)   | F ≡ ∃r.G, F ⊑ H           | \-                    | [∃r.G]                  |
+| Equivalent_classes(∃r.G)                   | F ≡ ∃r.G, F ⊑ H           | \-                    | [F]                    |
+| Instances(∃r.G)                            | F ≡ ∃r.G, F ⊑ H           | r(i,g) G(g)           | [i]                    |
+| Instances(F)                              | F ≡ ∃r.G, F ⊑ H           | r(i,g) G(g)           | [i]                    |
+| Instances(H)                              | F ≡ ∃r.G, F ⊑ H           | r(i,g) G(g)           | [i]                    |
+| types(i)                                  | F ≡ ∃r.G, F ⊑ H           | r(i,g) G(g)           | [H,F,T]                |
+| Sub_classes(C, only_named=False)          | A ⊓ B ≡ R, R ⊑ C          | \-                    | [R, A ⊓ B]             |
+| Super_classes(A ⊓ B)                      | A ⊓ B ≡ R, R ⊑ C          | \-                    | [R, C,A,B,T]           |
+| Equivalent_classes(R,<br>only_named=False) | A ⊓ B ≡ R, R ⊑ C          | \-                    | [A ⊓ B]                |
+| Equivalent_classes(A ⊓ B)                 | A ⊓ B ≡ R, R ⊑ C          | \-                    | [R]                    |
+| Instances(A ⊓ B)                          | A ⊓ B ≡ R, R ⊑ C          | R(e) A(a) B(a)        | [e,a]                  |
+| Instances(R)                              | A ⊓ B ≡ R, R ⊑ C          | R(e) A(a) B(a)        | [a, e]                 |
+| Instances(C)                              | A ⊓ B ≡ R, R ⊑ C          | R(e) A(a) B(a)        | [a, e]                 |
+| Types(a)                                  | A ⊓ B ≡ R, R ⊑ C          | R(e) A(a) B(a)        | [A,B,R,C,T]            |
+| Types(e)                                  | A ⊓ B ≡ R, R ⊑ C          | R(e) A(a) B(a)        | [A,B,R,C,T]            |
+| Sub_classes(D, only_named=False)          | ∃r.P ⊓ C ≡ E, E ⊑ D       | \-                    | [E, ∃r.P  ⊓ C]          |
+| Super_classes(∃r.P ⊓ C)                    | ∃r.P ⊓ C ≡ E, E ⊑ D       | \-                    | [E, D, T]              |
+| Equivalent_classes(∃r.P ⊓ C)               | ∃r.P ⊓ C ≡ E, E ⊑ D       | \-                    | [E]                    |
+| Equivalent_classes(E,<br>only_named=False) | ∃r.P ⊓ C ≡ E, E ⊑ D       | \-                    | [∃r.P ⊓ C]              |
+| Instances(∃r.P ⊓ C)                        | ∃r.P ⊓ C ≡ E, E ⊑ D       | r(x,y) C(x) P(y)      | [x]                    |
+| Instances(E)                              | ∃r.P ⊓ C ≡ E, E ⊑ D       | r(x,y) C(x) P(y)      | [x]                    |
+| Instances(D)                              | ∃r.P ⊓ C ≡ E, E ⊑ D       | r(x,y) C(x) P(y)      | [x]                    |
+| Types(x)                                  | ∃r.P ⊓ C ≡ E, E ⊑ D       | r(x,y) C(x) P(y)      | [C]                    |
+| disjoint_classes(A)                       | A ⊔ B                     | \-                    | [B]                    |
+| disjoint_classes(B)                       | A ⊔ B                     | \-                    | [A]                    |
+| disjoint_classes(A)                       | A ⊔ B, B ≡ C              | \-                    | [B, C]                 |
+| disjoint_classes(B)                       | A ⊔ B, B ≡ C              | \-                    | [A]                    |
+| disjoint_classes(C)                       | A ⊔ B, B ≡ C              | \-                    | [A]                    |
+| object_property_domains(r)                | Domain(r) = A             | \-                    | [A,T]                  |
+| object_property_domains(r)                | Domain(r) = A<br>A ≡ B    | \-                    | [A,T]                  |
+| object_property_domains(r2)               | Domain(r1) = A<br>r2 ⊑ r1 | \-                    | [A,T]                  |
+
+

--- a/docs/usage/usage_examples.md
+++ b/docs/usage/usage_examples.md
@@ -1,4 +1,4 @@
-# Usage
+# Basic Usage
 
 The main usage for owlapy is to use it for class expression construction. Class 
 expression learning algorithms require such basic structure to work upon. Let's walk 

--- a/owlapy/__init__.py
+++ b/owlapy/__init__.py
@@ -1,4 +1,4 @@
 from .render import owl_expression_to_dl, owl_expression_to_manchester
 from .parser import dl_to_owl_expression, manchester_to_owl_expression
 from .converter import owl_expression_to_sparql
-__version__ = '1.0.2'
+__version__ = '1.1.0'


### PR DESCRIPTION
- Added documentation for ontology manipulation and reasoning related classes. The following guides were updated and moved from Ontolearn to OWLAPY:
  - usage/ontologies
  - usage/reasoner
  - usage/reasoner_details

- Increased _\_\_version___ of owlapy to 1.1.0 #43
