### PR TITLE
Owlapy mapper extension and infer methods of adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ from owlapy.owlapi_adaptor import OWLAPIAdaptor
 
 adaptor = OWLAPIAdaptor(path="KGs/Family/family-benchmark_rich_background.owl", name_reasoner="Pellet")
 # Infer missing class assertions
-adaptor.infer_and_save(output_path="KGs/Family/inferred_family-benchmark_rich_background.ttl",
+adaptor.infer_axioms_and_save(output_path="KGs/Family/inferred_family-benchmark_rich_background.ttl",
                        output_format="ttl",
                        inference_types=[
                            "InferredClassAssertionAxiomGenerator",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,8 @@ html_logo = '_static/images/owlapy_logo.png'
 
 html_favicon = '_static/images/favicon.ico'
 
+html_extra_path = ["googlec4c425077889c69c.html"]
+
 if stanford_theme_mod:
     html_theme = 'sphinx_rtd_theme'
 

--- a/docs/googlec4c425077889c69c.html
+++ b/docs/googlec4c425077889c69c.html
@@ -1,0 +1,1 @@
+google-site-verification: googlec4c425077889c69c.html

--- a/owlapy/owl_axiom.py
+++ b/owlapy/owl_axiom.py
@@ -723,7 +723,8 @@ class OWLAnnotationAssertionAxiom(OWLAnnotationAxiom):
     _subject: OWLAnnotationSubject
     _annotation: OWLAnnotation
 
-    def __init__(self, subject: OWLAnnotationSubject, annotation: OWLAnnotation):
+    def __init__(self, subject: OWLAnnotationSubject, annotation: OWLAnnotation,
+                 annotations: Optional[Iterable['OWLAnnotation']] = None):
         """Get an annotation assertion axiom - with annotations.
 
         Args:
@@ -732,7 +733,7 @@ class OWLAnnotationAssertionAxiom(OWLAnnotationAxiom):
         """
         assert isinstance(subject, OWLAnnotationSubject)
         assert isinstance(annotation, OWLAnnotation)
-
+        super().__init__(annotations)
         self._subject = subject
         self._annotation = annotation
 
@@ -769,7 +770,7 @@ class OWLAnnotationAssertionAxiom(OWLAnnotationAxiom):
         return hash((self._subject, self._annotation))
 
     def __repr__(self):
-        return f'OWLAnnotationAssertionAxiom({self._subject}, {self._annotation})'
+        return f'OWLAnnotationAssertionAxiom({self._subject}, {self._annotation}, {self.annotations()})'
 class OWLSubAnnotationPropertyOfAxiom(OWLAnnotationAxiom):
     """An annotation subproperty axiom SubAnnotationPropertyOf( AP1 AP2 ) states that the annotation property AP1 is
     a subproperty of the annotation property AP2.

--- a/owlapy/owlapi_mapper.py
+++ b/owlapy/owlapi_mapper.py
@@ -1,21 +1,36 @@
 from functools import singledispatchmethod
+from typing import Generator
+
 import jpype.imports
 
 from owlapy import owl_expression_to_manchester, manchester_to_owl_expression
 from owlapy.class_expression import OWLClassExpression
 from owlapy.iri import IRI
+from owlapy.owl_axiom import OWLDeclarationAxiom, OWLAnnotation, OWLAnnotationProperty, OWLClassAssertionAxiom, \
+    OWLDataPropertyAssertionAxiom, OWLDataPropertyDomainAxiom, OWLDataPropertyRangeAxiom, OWLObjectPropertyDomainAxiom, \
+    OWLObjectPropertyRangeAxiom, OWLObjectPropertyAssertionAxiom, OWLEquivalentClassesAxiom, \
+    OWLEquivalentDataPropertiesAxiom, OWLEquivalentObjectPropertiesAxiom, OWLDisjointClassesAxiom, \
+    OWLDisjointDataPropertiesAxiom, OWLDisjointObjectPropertiesAxiom, OWLHasKeyAxiom, OWLSubDataPropertyOfAxiom, \
+    OWLSubClassOfAxiom, OWLSubObjectPropertyOfAxiom, OWLAsymmetricObjectPropertyAxiom, OWLDatatypeDefinitionAxiom, \
+    OWLDifferentIndividualsAxiom, OWLDisjointUnionAxiom, OWLFunctionalDataPropertyAxiom, \
+    OWLFunctionalObjectPropertyAxiom, OWLInverseFunctionalObjectPropertyAxiom, OWLInverseObjectPropertiesAxiom, \
+    OWLIrreflexiveObjectPropertyAxiom, OWLNegativeDataPropertyAssertionAxiom, OWLReflexiveObjectPropertyAxiom, \
+    OWLNegativeObjectPropertyAssertionAxiom, OWLSameIndividualAxiom, OWLSymmetricObjectPropertyAxiom, \
+    OWLTransitiveObjectPropertyAxiom, OWLAnnotationAssertionAxiom, OWLAnnotationPropertyDomainAxiom, \
+    OWLAnnotationPropertyRangeAxiom, OWLSubAnnotationPropertyOfAxiom
+from owlapy.owl_datatype import OWLDatatype
 from owlapy.owl_individual import OWLNamedIndividual
 from owlapy.owl_literal import OWLLiteral
 from owlapy.owl_property import OWLObjectProperty, OWLDataProperty
 
 if jpype.isJVMStarted():
-    from uk.ac.manchester.cs.owl.owlapi import OWLObjectPropertyImpl, OWLDataPropertyImpl, OWLNamedIndividualImpl
     from org.semanticweb.owlapi.model import IRI as owlapi_IRI
     from org.semanticweb.owlapi.manchestersyntax.parser import ManchesterOWLSyntaxClassExpressionParser
     from org.semanticweb.owlapi.manchestersyntax.renderer import ManchesterOWLSyntaxOWLObjectRendererImpl
     from org.semanticweb.owlapi.util import BidirectionalShortFormProviderAdapter, SimpleShortFormProvider
     from org.semanticweb.owlapi.expression import ShortFormEntityChecker
-    from java.util import HashSet
+    from java.util import HashSet, ArrayList, List, Set
+    from java.util.stream import Stream
     from uk.ac.manchester.cs.owl.owlapi import (OWLAnonymousClassExpressionImpl, OWLCardinalityRestrictionImpl,
                                                 OWLClassExpressionImpl, OWLClassImpl, OWLDataAllValuesFromImpl,
                                                 OWLDataCardinalityRestrictionImpl, OWLDataExactCardinalityImpl,
@@ -30,9 +45,44 @@ if jpype.isJVMStarted():
                                                 OWLObjectUnionOfImpl, OWLQuantifiedDataRestrictionImpl,
                                                 OWLQuantifiedObjectRestrictionImpl, OWLQuantifiedRestrictionImpl,
                                                 OWLValueRestrictionImpl, OWLLiteralImplBoolean, OWLLiteralImplString,
-                                                OWLLiteralImplDouble, OWLLiteralImplFloat, OWLLiteralImplInteger)
+                                                OWLLiteralImplDouble, OWLLiteralImplFloat, OWLLiteralImplInteger,
+                                                OWLDisjointClassesAxiomImpl, OWLDeclarationAxiomImpl, OWLAnnotationImpl,
+                                                OWLAnnotationPropertyImpl, OWLClassAssertionAxiomImpl,
+                                                OWLDataPropertyAssertionAxiomImpl, OWLDataPropertyDomainAxiomImpl,
+                                                OWLDataPropertyRangeAxiomImpl, OWLEquivalentClassesAxiomImpl,
+                                                OWLEquivalentDataPropertiesAxiomImpl,
+                                                OWLEquivalentObjectPropertiesAxiomImpl,
+                                                OWLObjectPropertyDomainAxiomImpl, OWLObjectPropertyRangeAxiomImpl,
+                                                OWLObjectPropertyAssertionAxiomImpl, OWLDisjointDataPropertiesAxiomImpl,
+                                                OWLDisjointObjectPropertiesAxiomImpl, OWLHasKeyAxiomImpl,
+                                                OWLSubClassOfAxiomImpl, OWLSubDataPropertyOfAxiomImpl,
+                                                OWLSubObjectPropertyOfAxiomImpl, OWLAsymmetricObjectPropertyAxiomImpl,
+                                                OWLDatatypeDefinitionAxiomImpl, OWLDatatypeImpl, OWLObjectPropertyImpl,
+                                                OWLDataPropertyImpl, OWLNamedIndividualImpl, OWLDisjointUnionAxiomImpl,
+                                                OWLDifferentIndividualsAxiomImpl, OWLFunctionalDataPropertyAxiomImpl,
+                                                OWLFunctionalObjectPropertyAxiomImpl, OWLSameIndividualAxiomImpl,
+                                                OWLInverseFunctionalObjectPropertyAxiomImpl,
+                                                OWLInverseObjectPropertiesAxiomImpl,OWLReflexiveObjectPropertyAxiomImpl,
+                                                OWLIrreflexiveObjectPropertyAxiomImpl,
+                                                OWLNegativeDataPropertyAssertionAxiomImpl,
+                                                OWLNegativeObjectPropertyAssertionAxiomImpl,
+                                                OWLSymmetricObjectPropertyAxiomImpl,
+                                                OWLTransitiveObjectPropertyAxiomImpl, OWLAnnotationAssertionAxiomImpl,
+                                                OWLAnnotationPropertyDomainAxiomImpl,
+                                                OWLAnnotationPropertyRangeAxiomImpl,
+                                                OWLSubAnnotationPropertyOfAxiomImpl
+                                                )
+
 else:
     raise ImportError("Jpype JVM is not started! Tip: Import OWLAPIMapper after JVM has started")
+
+
+def init(the_class):
+    cls_name = the_class.__class__.__name__
+    if "Impl" in cls_name:
+        return globals().get(cls_name.split(".")[-1].replace("Impl", ""))
+    else:
+        return globals().get(cls_name + "Impl")
 
 
 class OWLAPIMapper:
@@ -58,6 +108,7 @@ class OWLAPIMapper:
         self.parser = ManchesterOWLSyntaxClassExpressionParser(self.manager.getOWLDataFactory(), entity_checker)
         self.renderer = ManchesterOWLSyntaxOWLObjectRendererImpl()
 
+    # TODO AB: Implement mapping for DataRanges
     @singledispatchmethod
     def map_(self, e):
         """ (owlapy <--> owlapi) entity mapping.
@@ -65,31 +116,34 @@ class OWLAPIMapper:
         Args:
             e: OWL entity/expression.
         """
-        raise NotImplementedError()
+        if isinstance(e, Generator):
+            return self.map_(list(e))
+
+        raise NotImplementedError(f"Not implemented type: {e}")
 
     @map_.register
-    def _(self, e: OWLObjectProperty):
-        return OWLObjectPropertyImpl(owlapi_IRI.create(e.str))
+    def _(self, e: IRI):
+        return owlapi_IRI.create(e.str)
 
     @map_.register
-    def _(self, e: OWLObjectPropertyImpl):
-        return OWLObjectProperty(IRI.create(str(e.getIRI().getIRIString())))
+    def _(self, e: owlapi_IRI):
+        return IRI.create(str(e.getIRIString()))
 
-    @map_.register
-    def _(self, e: OWLDataProperty):
-        return OWLDataPropertyImpl(owlapi_IRI.create(e.str))
+    @map_.register(OWLNamedIndividual)
+    @map_.register(OWLDataProperty)
+    @map_.register(OWLObjectProperty)
+    @map_.register(OWLDatatype)
+    @map_.register(OWLAnnotationProperty)
+    def _(self, e):
+        return init(e)(self.map_(e.iri))
 
-    @map_.register
-    def _(self, e: OWLDataPropertyImpl):
-        return OWLDataProperty(IRI.create(str(e.getIRI().getIRIString())))
-
-    @map_.register
-    def _(self, e: OWLNamedIndividual):
-        return OWLNamedIndividualImpl(owlapi_IRI.create(e.str))
-
-    @map_.register
-    def _(self, e: OWLNamedIndividualImpl):
-        return OWLNamedIndividual(IRI.create(str(e.getIRI().getIRIString())))
+    @map_.register(OWLNamedIndividualImpl)
+    @map_.register(OWLDataPropertyImpl)
+    @map_.register(OWLObjectPropertyImpl)
+    @map_.register(OWLDatatypeImpl)
+    @map_.register(OWLAnnotationPropertyImpl)
+    def _(self, e):
+        return init(e)(self.map_(e.getIRI()))
 
     @map_.register
     def _(self, e: OWLClassExpression):
@@ -128,6 +182,11 @@ class OWLAPIMapper:
         # have to register all possible implementations
         return manchester_to_owl_expression(str(self.renderer.render(e)), self.namespace)
 
+    @map_.register
+    def _(self, e: OWLLiteral):
+        if e.is_string():
+            return OWLLiteralImplString(e.get_literal())
+
     @map_.register(OWLLiteralImplBoolean)
     def _(self, e):
         raw_value = str(e.getLiteral())
@@ -144,6 +203,224 @@ class OWLAPIMapper:
     def _(self, e):
         return OWLLiteral(str(e.getLiteral()))
 
-    @map_.register(OWLLiteralImplInteger)
-    def _(self, e):
+    @map_.register
+    def _(self, e: OWLLiteralImplInteger):
         return OWLLiteral(int(str(e.getLiteral())))
+
+    @map_.register
+    def _(self, e: OWLAnnotation):
+        return OWLAnnotationImpl(self.map_(e.get_property()), self.map_(e.get_value()), Stream.empty())
+
+    @map_.register
+    def _(self, e: OWLAnnotationImpl):
+        return OWLAnnotation(self.map_(e.getProperty()), self.map_(e.getValue()))
+
+    @map_.register
+    def _(self, e: OWLAnnotationAssertionAxiom):
+        return OWLAnnotationAssertionAxiomImpl(self.map_(e.get_subject()), self.map_(e.get_property()),
+                                               self.map_(e.get_value()), self.map_(e.annotations()))
+
+    @map_.register
+    def _(self, e: OWLAnnotationAssertionAxiomImpl):
+        return OWLAnnotationAssertionAxiom(self.map_(e.getSubject()),
+                                           OWLAnnotation(self.map_(e.getProperty()), self.map_(e.getValue())),
+                                           self.map_(e.annotationsAsList()))
+
+    @map_.register(OWLDeclarationAxiom)
+    def _(self, e):
+        return OWLDeclarationAxiomImpl(self.map_(e.get_entity()), self.map_(e.annotations()))
+
+    @map_.register(OWLDeclarationAxiomImpl)
+    def _(self, e):
+        return OWLDeclarationAxiom(self.map_(e.getEntity()), self.map_(e.annotationsAsList()))
+
+    @map_.register
+    def _(self, e: OWLClassAssertionAxiom):
+        return OWLClassAssertionAxiomImpl(self.map_(e.get_individual()), self.map_(e.get_class_expression()),
+                                          self.map_(e.annotations()))
+
+    @map_.register(OWLClassAssertionAxiomImpl)
+    def _(self, e):
+        return OWLClassAssertionAxiom(self.map_(e.getIndividual()), self.map_(e.getClassExpression()),
+                                      self.map_(e.annotationsAsList()))
+
+    @map_.register(OWLObjectPropertyAssertionAxiom)
+    @map_.register(OWLDataPropertyAssertionAxiom)
+    @map_.register(OWLNegativeDataPropertyAssertionAxiom)
+    @map_.register(OWLNegativeObjectPropertyAssertionAxiom)
+    def _(self, e):
+        return init(e)(self.map_(e.get_subject()), self.map_(e.get_property()), self.map_(e.get_object()),
+                       self.map_(e.annotations()))
+
+    @map_.register(OWLObjectPropertyAssertionAxiomImpl)
+    @map_.register(OWLDataPropertyAssertionAxiomImpl)
+    @map_.register(OWLNegativeDataPropertyAssertionAxiomImpl)
+    @map_.register(OWLNegativeObjectPropertyAssertionAxiomImpl)
+    def _(self, e):
+        return init(e)(self.map_(e.getSubject()), self.map_(e.getProperty()), self.map_(e.getObject()),
+                       self.map_(e.annotationsAsList()))
+
+    @map_.register(OWLObjectPropertyDomainAxiom)
+    @map_.register(OWLDataPropertyDomainAxiom)
+    @map_.register(OWLAnnotationPropertyDomainAxiom)
+    @map_.register(OWLAnnotationPropertyRangeAxiom)
+    def _(self, e):
+        return init(e)(self.map_(e.get_property()), self.map_(e.get_domain()), self.map_(e.annotations()))
+
+    @map_.register(OWLObjectPropertyDomainAxiomImpl)
+    @map_.register(OWLDataPropertyDomainAxiomImpl)
+    @map_.register(OWLAnnotationPropertyDomainAxiomImpl)
+    @map_.register(OWLAnnotationPropertyRangeAxiomImpl)
+    def _(self, e):
+        return init(e)(self.map_(e.getProperty()), self.map_(e.getDomain()), self.map_(e.annotationsAsList()))
+
+    @map_.register(OWLObjectPropertyRangeAxiom)
+    @map_.register(OWLDataPropertyRangeAxiom)
+    def _(self, e):
+        return init(e)(self.map_(e.get_property()), self.map_(e.get_range()), self.map_(e.annotations()))
+
+    @map_.register(OWLObjectPropertyRangeAxiomImpl)
+    @map_.register(OWLDataPropertyRangeAxiomImpl)
+    def _(self, e):
+        return init(e)(self.map_(e.getProperty()), self.map_(e.getRange()), self.map_(e.annotationsAsList()))
+
+    @map_.register(OWLEquivalentDataPropertiesAxiom)
+    @map_.register(OWLEquivalentObjectPropertiesAxiom)
+    def _(self, e):
+        return init(e)(self.map_(e.properties()), self.map_(e.annotations()))
+
+    @map_.register(OWLEquivalentClassesAxiomImpl)
+    @map_.register(OWLEquivalentDataPropertiesAxiomImpl)
+    @map_.register(OWLEquivalentObjectPropertiesAxiomImpl)
+    def _(self, e):
+        return init(e)(self.map_(e.getOperandsAsList()), self.map_(e.annotationsAsList()))
+
+    @map_.register(OWLEquivalentClassesAxiom)
+    @map_.register(OWLDisjointClassesAxiom)
+    def _(self, e):
+        return init(e)(self.map_(e.class_expressions()), self.map_(e.annotations()))
+
+    @map_.register(OWLDisjointDataPropertiesAxiom)
+    @map_.register(OWLDisjointObjectPropertiesAxiom)
+    def _(self, e):
+        return init(e)(self.map_(e.properties()), self.map_(e.annotations()))
+
+    @map_.register(OWLDisjointClassesAxiomImpl)
+    @map_.register(OWLDisjointDataPropertiesAxiomImpl)
+    @map_.register(OWLDisjointObjectPropertiesAxiomImpl)
+    def _(self, e):
+        return init(e)(self.map_(e.getOperandsAsList()), self.map_(e.annotationsAsList()))
+
+    @map_.register
+    def _(self, e: OWLHasKeyAxiom):
+        return OWLHasKeyAxiomImpl(self.map_(e.get_class_expression()), self.map_(e.get_property_expressions()),
+                                  self.map_(e.annotations()))
+
+    @map_.register(OWLHasKeyAxiomImpl)
+    def _(self, e):
+        return OWLHasKeyAxiom(self.map_(e.getClassExpression()), self.map_(e.getOperandsAsList()),
+                              self.map_(e.annotationsAsList()))
+
+    @map_.register
+    def _(self, e: OWLSubClassOfAxiom):
+        return OWLSubClassOfAxiomImpl(self.map_(e.get_sub_class()), self.map_(e.get_super_class()),
+                                      self.map_(e.annotations()))
+
+    @map_.register(OWLSubClassOfAxiomImpl)
+    def _(self, e):
+        return OWLSubClassOfAxiom(self.map_(e.getSubClass()), self.map_(e.getSuperClass()),
+                                  self.map_(e.annotationsAsList()))
+
+    @map_.register(OWLSubDataPropertyOfAxiom)
+    @map_.register(OWLSubObjectPropertyOfAxiom)
+    @map_.register(OWLSubAnnotationPropertyOfAxiom)
+    def _(self, e):
+        return init(e)(self.map_(e.get_sub_property()), self.map_(e.get_super_property()), self.map_(e.annotations()))
+
+    @map_.register(OWLSubDataPropertyOfAxiomImpl)
+    @map_.register(OWLSubObjectPropertyOfAxiomImpl)
+    @map_.register(OWLSubAnnotationPropertyOfAxiomImpl)
+    def _(self, e):
+        return init(e)(self.map_(e.getSubProperty()), self.map_(e.getSuperProperty()),
+                       self.map_(e.annotationsAsList()))
+
+    @map_.register(OWLAsymmetricObjectPropertyAxiom)
+    @map_.register(OWLFunctionalDataPropertyAxiom)
+    @map_.register(OWLFunctionalObjectPropertyAxiom)
+    @map_.register(OWLInverseFunctionalObjectPropertyAxiom)
+    @map_.register(OWLIrreflexiveObjectPropertyAxiom)
+    @map_.register(OWLReflexiveObjectPropertyAxiom)
+    @map_.register(OWLSymmetricObjectPropertyAxiom)
+    @map_.register(OWLTransitiveObjectPropertyAxiom)
+    def _(self, e):
+        return init(e)(self.map_(e.get_property()), self.map_(e.annotations()))
+
+    @map_.register(OWLAsymmetricObjectPropertyAxiomImpl)
+    @map_.register(OWLFunctionalDataPropertyAxiomImpl)
+    @map_.register(OWLFunctionalObjectPropertyAxiomImpl)
+    @map_.register(OWLInverseFunctionalObjectPropertyAxiomImpl)
+    @map_.register(OWLIrreflexiveObjectPropertyAxiomImpl)
+    @map_.register(OWLReflexiveObjectPropertyAxiomImpl)
+    @map_.register(OWLSymmetricObjectPropertyAxiomImpl)
+    @map_.register(OWLTransitiveObjectPropertyAxiomImpl)
+    def _(self, e):
+        return init(e)(self.map_(e.getProperty()), self.map_(e.annotationsAsList()))
+
+    @map_.register(OWLDatatypeDefinitionAxiom)
+    def _(self, e):
+        return OWLDatatypeDefinitionAxiomImpl(self.map_(e.get_datatype()), self.map_(e.get_datarange()),
+                                              self.map_(e.annotations()))
+
+    @map_.register(OWLDatatypeDefinitionAxiomImpl)
+    def _(self, e):
+        return OWLDatatypeDefinitionAxiom(self.map_(e.getDatatype()), self.map_(e.getDataRange()),
+                                          self.map_(e.annotationsAsList()))
+
+    @map_.register(OWLDifferentIndividualsAxiom)
+    @map_.register(OWLSameIndividualAxiom)
+    def _(self, e):
+        return OWLDifferentIndividualsAxiomImpl(self.map_(e.individuals()), self.map_(e.annotations()))
+
+    @map_.register(OWLDifferentIndividualsAxiomImpl)
+    @map_.register(OWLSameIndividualAxiomImpl)
+    def _(self, e):
+        return OWLDifferentIndividualsAxiom(self.map_(e.getIndividualsAsList()), self.map_(e.annotationsAsList()))
+
+    @map_.register(OWLDisjointUnionAxiom)
+    def _(self, e):
+        return OWLDisjointUnionAxiomImpl(self.map_(e.get_owl_class()), self.map_(e.get_class_expressions()).stream(),
+                                         self.map_(e.annotations()))
+
+    @map_.register(OWLDisjointUnionAxiomImpl)
+    def _(self, e):
+        return OWLDisjointUnionAxiom(self.map_(e.getOWLClass()), self.map_(e.getOperandsAsList()),
+                                     self.map_(e.annotationsAsList()))
+
+    @map_.register(OWLInverseObjectPropertiesAxiom)
+    def _(self, e):
+        return OWLInverseObjectPropertiesAxiomImpl(self.map_(e.get_first_property()),
+                                                   self.map_(e.get_second_property()), self.map_(e.annotations()))
+
+    @map_.register(OWLInverseObjectPropertiesAxiomImpl)
+    def _(self, e):
+        return OWLInverseObjectPropertiesAxiom(self.map_(e.getFirstProperty()), self.map_(e.getSecondProperty()),
+                                               self.map_(e.annotationsAsList()))
+
+    @map_.register(List)
+    @map_.register(Set)
+    def _(self, e):
+        python_list = list()
+        casted_list = list(e)
+        if e and len(casted_list) > 0:
+            for obj in list(e):
+                python_list.append(self.map_(obj))
+        return python_list
+
+    @map_.register(list)
+    @map_.register(set)
+    def _(self, e):
+        java_list = ArrayList()
+        if e is not None and len(e) > 0:
+            for item in e:
+                java_list.add(self.map_(item))
+        return java_list


### PR DESCRIPTION
### Owlapi Mapper
- added mappings for all type of _**axioms**_
- added mappings for all _**data ranges**_ 
- added mappings for _**literals**_
- added mappings for annotations
- added mappings for 'hasIRI' implementors

### Owlapy Adapter
- `infer_and_save` method renamed to `infer_axioms_and_save`
- added `infer_axioms` method which behave similar to `infer_axioms_and_save` but will instead return the axioms as OWLAPY classes 
- added more types of inference that can be used in the parameter `inference_types` for the above mentioned methods.
- renamed method `generate_inferred_class_assertion_axioms` to `generate_and_save_inferred_class_assertion_axioms` to avoid confusion.
- added docstrings for `infer_and_save` as well as for `infer_axioms` where its now clearer to know the valid input for the `inference_types` argument.

#### Google Console Indexing
- Added owlapys documentation to Google Search Console for better indexing.
    - file `docs/googlec4c425077889c69c.html` needed for verification by google. It should always be there so please do not remove.