### PR TITLE
Issues solving

### DIFF
--- a/owlapy/abstracts/__init__.py
+++ b/owlapy/abstracts/__init__.py
@@ -1,4 +1,5 @@
-from .abstract_owl_ontology_manager import OWLOntologyManager, OWLOntologyChange, OWLOntology
-from .abstract_owl_reasoner import OWLReasoner, OWLReasonerEx
+from .abstract_owl_ontology_manager import AbstractOWLOntologyManager, AbstractOWLOntologyChange, AbstractOWLOntology
+from .abstract_owl_reasoner import AbstractOWLReasoner, AbstractOWLReasonerEx
 
-__all__ = ['OWLOntologyManager', 'OWLOntologyChange', 'OWLOntology', 'OWLReasoner', 'OWLReasonerEx']
+__all__ = ['AbstractOWLOntologyManager', 'AbstractOWLOntologyChange', 'AbstractOWLOntology', 'AbstractOWLReasoner',
+           'AbstractOWLReasonerEx']

--- a/owlapy/abstracts/abstract_owl_ontology.py
+++ b/owlapy/abstracts/abstract_owl_ontology.py
@@ -13,7 +13,7 @@ _M = TypeVar('_M', bound='OWLOntologyManager')  # noqa: F821
 _OI = TypeVar('_OI', bound='OWLOntologyID')  # noqa: F821
 
 
-class OWLOntology(OWLObject, metaclass=ABCMeta):
+class AbstractOWLOntology(OWLObject, metaclass=ABCMeta):
     """Represents an OWL 2 Ontology  in the OWL 2 specification.
 
     An OWLOntology consists of a possibly empty set of OWLAxioms and a possibly empty set of OWLAnnotations.

--- a/owlapy/abstracts/abstract_owl_ontology_manager.py
+++ b/owlapy/abstracts/abstract_owl_ontology_manager.py
@@ -1,21 +1,21 @@
 from abc import ABCMeta, abstractmethod
 from typing import Union
 
-from owlapy.abstracts.abstract_owl_ontology import OWLOntology
+from owlapy.abstracts.abstract_owl_ontology import AbstractOWLOntology
 from owlapy.iri import IRI
 
 
-class OWLOntologyChange(metaclass=ABCMeta):
+class AbstractOWLOntologyChange(metaclass=ABCMeta):
     """Represents an ontology change."""
     __slots__ = ()
 
-    _ont: OWLOntology
+    _ont: AbstractOWLOntology
 
     @abstractmethod
-    def __init__(self, ontology: OWLOntology):
+    def __init__(self, ontology: AbstractOWLOntology):
         self._ont = ontology
 
-    def get_ontology(self) -> OWLOntology:
+    def get_ontology(self) -> AbstractOWLOntology:
         """Gets the ontology that the change is/was applied to.
 
         Returns:
@@ -24,12 +24,12 @@ class OWLOntologyChange(metaclass=ABCMeta):
         return self._ont
 
 
-class OWLOntologyManager(metaclass=ABCMeta):
+class AbstractOWLOntologyManager(metaclass=ABCMeta):
     """An OWLOntologyManager manages a set of ontologies. It is the main point for creating, loading and accessing
     ontologies."""
 
     @abstractmethod
-    def create_ontology(self, iri: Union[str, IRI]) -> OWLOntology:
+    def create_ontology(self, iri: Union[str, IRI]) -> AbstractOWLOntology:
         """Creates a new (empty) ontology that that has the specified ontology IRI (and no version IRI).
 
         Args:
@@ -41,7 +41,7 @@ class OWLOntologyManager(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def load_ontology(self, iri: Union[IRI, str]) -> OWLOntology:
+    def load_ontology(self, iri: Union[IRI, str]) -> AbstractOWLOntology:
         """Loads an ontology that is assumed to have the specified ontology IRI as its IRI or version IRI. The ontology
         IRI will be mapped to an ontology document IRI.
 
@@ -56,7 +56,7 @@ class OWLOntologyManager(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def apply_change(self, change: OWLOntologyChange):
+    def apply_change(self, change: AbstractOWLOntologyChange):
         """A convenience method that applies just one change to an ontology. When this method is used through an
         OWLOntologyManager implementation, the instance used should be the one that the ontology returns through the
         get_owl_ontology_manager() call.

--- a/owlapy/abstracts/abstract_owl_reasoner.py
+++ b/owlapy/abstracts/abstract_owl_reasoner.py
@@ -8,7 +8,7 @@ from owlapy.class_expression import OWLClassExpression
 from owlapy.class_expression import OWLClass
 from owlapy.owl_data_ranges import OWLDataRange
 from owlapy.owl_object import OWLEntity
-from owlapy.abstracts.abstract_owl_ontology import OWLOntology
+from owlapy.abstracts.abstract_owl_ontology import AbstractOWLOntology
 from owlapy.owl_property import OWLObjectPropertyExpression, OWLDataProperty, OWLObjectProperty
 from owlapy.owl_individual import OWLNamedIndividual
 from owlapy.owl_literal import OWLLiteral
@@ -16,13 +16,13 @@ from owlapy.owl_literal import OWLLiteral
 logger = logging.getLogger(__name__)
 
 
-class OWLReasoner(metaclass=ABCMeta):
+class AbstractOWLReasoner(metaclass=ABCMeta):
     """An OWLReasoner reasons over a set of axioms (the set of reasoner axioms) that is based on the imports closure of
     a particular ontology - the "root" ontology."""
     __slots__ = ()
 
     @abstractmethod
-    def __init__(self, ontology: OWLOntology):
+    def __init__(self, ontology: AbstractOWLOntology):
         pass
 
     @abstractmethod
@@ -353,7 +353,7 @@ class OWLReasoner(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def get_root_ontology(self) -> OWLOntology:
+    def get_root_ontology(self) -> AbstractOWLOntology:
         """Gets the "root" ontology that is loaded into this reasoner. The reasoner takes into account the axioms in
         this ontology and its import's closure."""
         pass
@@ -377,7 +377,7 @@ class OWLReasoner(metaclass=ABCMeta):
         pass
 
 
-class OWLReasonerEx(OWLReasoner, metaclass=ABCMeta):
+class AbstractOWLReasonerEx(AbstractOWLReasoner, metaclass=ABCMeta):
     """Extra convenience methods for OWL Reasoners"""
 
     # default

--- a/owlapy/owl_hierarchy.py
+++ b/owlapy/owl_hierarchy.py
@@ -9,7 +9,7 @@ from owlapy.class_expression import OWLClass, OWLThing, OWLNothing
 from owlapy.meta_classes import HasIRI
 from owlapy.owl_literal import OWLTopObjectProperty, OWLBottomObjectProperty, OWLTopDataProperty, OWLBottomDataProperty
 from owlapy.owl_property import OWLObjectProperty, OWLDataProperty
-from owlapy.abstracts.abstract_owl_reasoner import OWLReasoner
+from owlapy.abstracts.abstract_owl_reasoner import AbstractOWLReasoner
 
 _S = TypeVar('_S', bound=HasIRI)  #:
 _U = TypeVar('_U', bound='AbstractHierarchy')  #:
@@ -40,20 +40,20 @@ class AbstractHierarchy(Generic[_S], metaclass=ABCMeta):
         ...
 
     @overload
-    def __init__(self, factory: Type[_S], reasoner: OWLReasoner):
+    def __init__(self, factory: Type[_S], reasoner: AbstractOWLReasoner):
         ...
 
     @abstractmethod
     def __init__(self, factory: Type[_S], arg):
         self._Type = factory
-        if isinstance(arg, OWLReasoner):
+        if isinstance(arg, AbstractOWLReasoner):
             hier_down_gen = self._hierarchy_down_generator(arg)
             self._init(hier_down_gen)
         else:
             self._init(arg)
 
     @abstractmethod
-    def _hierarchy_down_generator(self, reasoner: OWLReasoner) -> Iterable[Tuple[_S, Iterable[_S]]]:
+    def _hierarchy_down_generator(self, reasoner: AbstractOWLReasoner) -> Iterable[Tuple[_S, Iterable[_S]]]:
         """Generate the suitable downwards hierarchy based on the reasoner."""
         pass
 
@@ -263,7 +263,7 @@ class ClassHierarchy(AbstractHierarchy[OWLClass]):
     def get_bottom_entity(cls) -> OWLClass:
         return OWLNothing
 
-    def _hierarchy_down_generator(self, reasoner: OWLReasoner) -> Iterable[Tuple[OWLClass, Iterable[OWLClass]]]:
+    def _hierarchy_down_generator(self, reasoner: AbstractOWLReasoner) -> Iterable[Tuple[OWLClass, Iterable[OWLClass]]]:
         yield from ((_, reasoner.sub_classes(_, direct=True))
                     for _ in reasoner.get_root_ontology().classes_in_signature())
 
@@ -280,7 +280,7 @@ class ClassHierarchy(AbstractHierarchy[OWLClass]):
     def __init__(self, hierarchy_down: Iterable[Tuple[OWLClass, Iterable[OWLClass]]]): ...
 
     @overload
-    def __init__(self, reasoner: OWLReasoner): ...
+    def __init__(self, reasoner: AbstractOWLReasoner): ...
 
     def __init__(self, arg):
         super().__init__(OWLClass, arg)
@@ -296,7 +296,7 @@ class ObjectPropertyHierarchy(AbstractHierarchy[OWLObjectProperty]):
     def get_bottom_entity(cls) -> OWLObjectProperty:
         return OWLBottomObjectProperty
 
-    def _hierarchy_down_generator(self, reasoner: OWLReasoner) \
+    def _hierarchy_down_generator(self, reasoner: AbstractOWLReasoner) \
             -> Iterable[Tuple[OWLObjectProperty, Iterable[OWLObjectProperty]]]:
         return ((_, map(lambda _: cast(OWLObjectProperty, _),
                         filter(lambda _: isinstance(_, OWLObjectProperty),
@@ -328,7 +328,7 @@ class ObjectPropertyHierarchy(AbstractHierarchy[OWLObjectProperty]):
     def __init__(self, hierarchy_down: Iterable[Tuple[OWLObjectProperty, Iterable[OWLObjectProperty]]]): ...
 
     @overload
-    def __init__(self, reasoner: OWLReasoner): ...
+    def __init__(self, reasoner: AbstractOWLReasoner): ...
 
     def __init__(self, arg):
         super().__init__(OWLObjectProperty, arg)
@@ -344,7 +344,7 @@ class DatatypePropertyHierarchy(AbstractHierarchy[OWLDataProperty]):
     def get_bottom_entity(cls) -> OWLDataProperty:
         return OWLBottomDataProperty
 
-    def _hierarchy_down_generator(self, reasoner: OWLReasoner) \
+    def _hierarchy_down_generator(self, reasoner: AbstractOWLReasoner) \
             -> Iterable[Tuple[OWLDataProperty, Iterable[OWLDataProperty]]]:
         return ((_, reasoner.sub_data_properties(_, direct=True))
                 for _ in reasoner.get_root_ontology().data_properties_in_signature())
@@ -374,7 +374,7 @@ class DatatypePropertyHierarchy(AbstractHierarchy[OWLDataProperty]):
     def __init__(self, hierarchy_down: Iterable[Tuple[OWLDataProperty, Iterable[OWLDataProperty]]]): ...
 
     @overload
-    def __init__(self, reasoner: OWLReasoner): ...
+    def __init__(self, reasoner: AbstractOWLReasoner): ...
 
     def __init__(self, arg):
         super().__init__(OWLDataProperty, arg)

--- a/owlapy/owl_ontology.py
+++ b/owlapy/owl_ontology.py
@@ -8,7 +8,7 @@ import logging
 import owlready2
 from pandas import Timedelta
 from owlapy import namespaces
-from owlapy.abstracts.abstract_owl_ontology import OWLOntology
+from owlapy.abstracts.abstract_owl_ontology import AbstractOWLOntology
 from owlapy.owl_data_ranges import OWLDataRange, OWLDataComplementOf, OWLDataUnionOf, OWLDataIntersectionOf
 from owlapy.owl_datatype import OWLDatatype
 from owlapy.owl_individual import OWLNamedIndividual, OWLIndividual
@@ -124,7 +124,7 @@ class OWLOntologyID:
         return NotImplemented
 
 
-def _check_expression(expr: OWLObject, ontology: OWLOntology, world: owlready2.namespace.World):
+def _check_expression(expr: OWLObject, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     """
     @TODO:CD: Documentation
     Creates all entities (individuals, classes, properties) that appear in the given (complex) class expression
@@ -149,12 +149,12 @@ def _check_expression(expr: OWLObject, ontology: OWLOntology, world: owlready2.n
 
 
 @singledispatch
-def _add_axiom(axiom: OWLAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _add_axiom(axiom: OWLAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     raise NotImplementedError(f'Axiom type {axiom} is not implemented yet.')
 
 
 @_add_axiom.register
-def _(axiom: OWLDeclarationAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLDeclarationAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.namespace.Ontology = conv.map_object(ontology)
 
@@ -185,7 +185,7 @@ def _(axiom: OWLDeclarationAxiom, ontology: OWLOntology, world: owlready2.namesp
 
 
 @_add_axiom.register
-def _(axiom: OWLClassAssertionAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLClassAssertionAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.namespace.Ontology = conv.map_object(ontology)
 
@@ -203,7 +203,7 @@ def _(axiom: OWLClassAssertionAxiom, ontology: OWLOntology, world: owlready2.nam
 
 
 @_add_axiom.register
-def _(axiom: OWLObjectPropertyAssertionAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLObjectPropertyAssertionAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.namespace.Ontology = conv.map_object(ontology)
 
@@ -221,7 +221,7 @@ def _(axiom: OWLObjectPropertyAssertionAxiom, ontology: OWLOntology, world: owlr
 
 
 @_add_axiom.register
-def _(axiom: OWLDataPropertyAssertionAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLDataPropertyAssertionAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.namespace.Ontology = conv.map_object(ontology)
 
@@ -236,7 +236,7 @@ def _(axiom: OWLDataPropertyAssertionAxiom, ontology: OWLOntology, world: owlrea
 
 
 @_add_axiom.register
-def _(axiom: OWLSubClassOfAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLSubClassOfAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.namespace.Ontology = conv.map_object(ontology)
 
@@ -262,7 +262,7 @@ def _(axiom: OWLSubClassOfAxiom, ontology: OWLOntology, world: owlready2.namespa
 
 # TODO: Update as soon as owlready2 adds support for EquivalentClasses general class axioms
 @_add_axiom.register
-def _(axiom: OWLEquivalentClassesAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLEquivalentClassesAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x = conv.map_object(ontology)
 
@@ -295,7 +295,7 @@ def _(axiom: OWLEquivalentClassesAxiom, ontology: OWLOntology, world: owlready2.
 
 
 @_add_axiom.register
-def _(axiom: OWLDisjointClassesAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLDisjointClassesAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.Ontology = conv.map_object(ontology)
 
@@ -308,7 +308,7 @@ def _(axiom: OWLDisjointClassesAxiom, ontology: OWLOntology, world: owlready2.na
 
 
 @_add_axiom.register
-def _(axiom: OWLDisjointUnionAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLDisjointUnionAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.Ontology = conv.map_object(ontology)
 
@@ -322,7 +322,7 @@ def _(axiom: OWLDisjointUnionAxiom, ontology: OWLOntology, world: owlready2.name
 
 
 @_add_axiom.register
-def _(axiom: OWLAnnotationAssertionAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLAnnotationAssertionAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.Ontology = conv.map_object(ontology)
 
@@ -348,7 +348,7 @@ def _(axiom: OWLAnnotationAssertionAxiom, ontology: OWLOntology, world: owlready
 
 
 @_add_axiom.register
-def _(axiom: OWLNaryIndividualAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLNaryIndividualAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.Ontology = conv.map_object(ontology)
 
@@ -368,7 +368,7 @@ def _(axiom: OWLNaryIndividualAxiom, ontology: OWLOntology, world: owlready2.nam
 
 
 @_add_axiom.register
-def _(axiom: OWLSubPropertyAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLSubPropertyAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.Ontology = conv.map_object(ontology)
 
@@ -383,7 +383,7 @@ def _(axiom: OWLSubPropertyAxiom, ontology: OWLOntology, world: owlready2.namesp
 
 
 @_add_axiom.register
-def _(axiom: OWLPropertyDomainAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLPropertyDomainAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.Ontology = conv.map_object(ontology)
 
@@ -398,7 +398,7 @@ def _(axiom: OWLPropertyDomainAxiom, ontology: OWLOntology, world: owlready2.nam
 
 
 @_add_axiom.register
-def _(axiom: OWLPropertyRangeAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLPropertyRangeAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.Ontology = conv.map_object(ontology)
 
@@ -415,7 +415,7 @@ def _(axiom: OWLPropertyRangeAxiom, ontology: OWLOntology, world: owlready2.name
 
 
 @_add_axiom.register
-def _(axiom: OWLNaryPropertyAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLNaryPropertyAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.Ontology = conv.map_object(ontology)
 
@@ -441,7 +441,7 @@ def _(axiom: OWLNaryPropertyAxiom, ontology: OWLOntology, world: owlready2.names
 
 
 @_add_axiom.register
-def _(axiom: OWLObjectPropertyCharacteristicAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLObjectPropertyCharacteristicAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.Ontology = conv.map_object(ontology)
 
@@ -468,7 +468,7 @@ def _(axiom: OWLObjectPropertyCharacteristicAxiom, ontology: OWLOntology, world:
 
 
 @_add_axiom.register
-def _(axiom: OWLDataPropertyCharacteristicAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLDataPropertyCharacteristicAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.Ontology = conv.map_object(ontology)
 
@@ -483,12 +483,12 @@ def _(axiom: OWLDataPropertyCharacteristicAxiom, ontology: OWLOntology, world: o
 
 
 @singledispatch
-def _remove_axiom(axiom: OWLAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _remove_axiom(axiom: OWLAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     raise NotImplementedError(f'Axiom type {axiom} is not implemented yet.')
 
 
 @_remove_axiom.register
-def _(axiom: OWLDeclarationAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLDeclarationAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.namespace.Ontology = conv.map_object(ontology)
     with ont_x:
@@ -499,7 +499,7 @@ def _(axiom: OWLDeclarationAxiom, ontology: OWLOntology, world: owlready2.namesp
 
 
 @_remove_axiom.register
-def _(axiom: OWLClassAssertionAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLClassAssertionAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.namespace.Ontology = conv.map_object(ontology)
 
@@ -515,7 +515,7 @@ def _(axiom: OWLClassAssertionAxiom, ontology: OWLOntology, world: owlready2.nam
 
 
 @_remove_axiom.register
-def _(axiom: OWLObjectPropertyAssertionAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLObjectPropertyAssertionAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.namespace.Ontology = conv.map_object(ontology)
 
@@ -528,7 +528,7 @@ def _(axiom: OWLObjectPropertyAssertionAxiom, ontology: OWLOntology, world: owlr
 
 
 @_remove_axiom.register
-def _(axiom: OWLDataPropertyAssertionAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLDataPropertyAssertionAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.namespace.Ontology = conv.map_object(ontology)
 
@@ -541,7 +541,7 @@ def _(axiom: OWLDataPropertyAssertionAxiom, ontology: OWLOntology, world: owlrea
 
 
 @_remove_axiom.register
-def _(axiom: OWLSubClassOfAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLSubClassOfAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.namespace.Ontology = conv.map_object(ontology)
     sub_class = axiom.get_sub_class()
@@ -566,7 +566,7 @@ def _(axiom: OWLSubClassOfAxiom, ontology: OWLOntology, world: owlready2.namespa
 
 # TODO: Update as soons as owlready2 adds support for EquivalentClasses general class axioms
 @_remove_axiom.register
-def _(axiom: OWLEquivalentClassesAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLEquivalentClassesAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x = conv.map_object(ontology)
 
@@ -586,7 +586,7 @@ def _(axiom: OWLEquivalentClassesAxiom, ontology: OWLOntology, world: owlready2.
 
 
 @_remove_axiom.register
-def _(axiom: OWLDisjointClassesAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLDisjointClassesAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.Ontology = conv.map_object(ontology)
 
@@ -601,7 +601,7 @@ def _(axiom: OWLDisjointClassesAxiom, ontology: OWLOntology, world: owlready2.na
 
 
 @_remove_axiom.register
-def _(axiom: OWLDisjointUnionAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLDisjointUnionAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.Ontology = conv.map_object(ontology)
     assert isinstance(axiom.get_owl_class(), OWLClass), f'({axiom.get_owl_class()}) is not a named class.'
@@ -617,7 +617,7 @@ def _(axiom: OWLDisjointUnionAxiom, ontology: OWLOntology, world: owlready2.name
 
 
 @_remove_axiom.register
-def _(axiom: OWLAnnotationAssertionAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLAnnotationAssertionAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.Ontology = conv.map_object(ontology)
 
@@ -637,7 +637,7 @@ def _(axiom: OWLAnnotationAssertionAxiom, ontology: OWLOntology, world: owlready
 
 
 @_remove_axiom.register
-def _(axiom: OWLNaryIndividualAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLNaryIndividualAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.Ontology = conv.map_object(ontology)
 
@@ -663,7 +663,7 @@ def _(axiom: OWLNaryIndividualAxiom, ontology: OWLOntology, world: owlready2.nam
 
 
 @_remove_axiom.register
-def _(axiom: OWLSubPropertyAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLSubPropertyAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.namespace.Ontology = conv.map_object(ontology)
 
@@ -679,7 +679,7 @@ def _(axiom: OWLSubPropertyAxiom, ontology: OWLOntology, world: owlready2.namesp
 
 
 @_remove_axiom.register
-def _(axiom: OWLPropertyDomainAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLPropertyDomainAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.Ontology = conv.map_object(ontology)
 
@@ -691,7 +691,7 @@ def _(axiom: OWLPropertyDomainAxiom, ontology: OWLOntology, world: owlready2.nam
 
 
 @_remove_axiom.register
-def _(axiom: OWLPropertyRangeAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLPropertyRangeAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.Ontology = conv.map_object(ontology)
 
@@ -704,7 +704,7 @@ def _(axiom: OWLPropertyRangeAxiom, ontology: OWLOntology, world: owlready2.name
 
 
 @_remove_axiom.register
-def _(axiom: OWLNaryPropertyAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLNaryPropertyAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.Ontology = conv.map_object(ontology)
 
@@ -738,7 +738,7 @@ def _(axiom: OWLNaryPropertyAxiom, ontology: OWLOntology, world: owlready2.names
 
 
 @_remove_axiom.register
-def _(axiom: OWLObjectPropertyCharacteristicAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLObjectPropertyCharacteristicAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.Ontology = conv.map_object(ontology)
 
@@ -767,7 +767,7 @@ def _(axiom: OWLObjectPropertyCharacteristicAxiom, ontology: OWLOntology, world:
 
 
 @_remove_axiom.register
-def _(axiom: OWLDataPropertyCharacteristicAxiom, ontology: OWLOntology, world: owlready2.namespace.World):
+def _(axiom: OWLDataPropertyCharacteristicAxiom, ontology: AbstractOWLOntology, world: owlready2.namespace.World):
     conv = ToOwlready2(world)
     ont_x: owlready2.Ontology = conv.map_object(ontology)
 
@@ -778,7 +778,7 @@ def _(axiom: OWLDataPropertyCharacteristicAxiom, ontology: OWLOntology, world: o
             property_x.is_a.remove(owlready2.FunctionalProperty)
 
 
-class Ontology(OWLOntology):
+class Ontology(AbstractOWLOntology):
     __slots__ = '_manager', '_iri', '_world', '_onto'
 
     _manager: _OM
@@ -970,7 +970,7 @@ class Ontology(OWLOntology):
         return f'Ontology({self._onto.base_iri}, loaded:{self._onto.loaded})'
 
 
-class SyncOntology(OWLOntology):
+class SyncOntology(AbstractOWLOntology):
 
     def __init__(self, manager: _SM, path: Union[IRI, str], new: bool = False):
         from owlapy.owlapi_mapper import OWLAPIMapper
@@ -1094,7 +1094,7 @@ class ToOwlready2:
         return self.map_concept(ce)
 
     @map_object.register
-    def _(self, ont: OWLOntology) -> owlready2.namespace.Ontology:
+    def _(self, ont: AbstractOWLOntology) -> owlready2.namespace.Ontology:
         return self._world.get_ontology(
             ont.get_ontology_id().get_ontology_iri().as_str()
         )

--- a/owlapy/owl_ontology_manager.py
+++ b/owlapy/owl_ontology_manager.py
@@ -3,11 +3,11 @@ from typing import Union
 import jpype
 import owlready2
 
-from owlapy.abstracts.abstract_owl_ontology_manager import OWLOntologyChange, OWLOntologyManager
+from owlapy.abstracts.abstract_owl_ontology_manager import AbstractOWLOntologyChange, AbstractOWLOntologyManager
 from owlapy.iri import IRI
 from owlapy.meta_classes import HasIRI
 from owlapy.owl_ontology import Ontology, SyncOntology
-from owlapy.abstracts.abstract_owl_ontology import OWLOntology
+from owlapy.abstracts.abstract_owl_ontology import AbstractOWLOntology
 from owlapy.static_funcs import startJVM
 
 
@@ -41,11 +41,11 @@ class OWLImportsDeclaration(HasIRI):
         return self._iri.as_str()
 
 
-class AddImport(OWLOntologyChange):
+class AddImport(AbstractOWLOntologyChange):
     """Represents an ontology change where an import statement is added to an ontology."""
     __slots__ = '_ont', '_declaration'
 
-    def __init__(self, ontology: OWLOntology, import_declaration: OWLImportsDeclaration):
+    def __init__(self, ontology: AbstractOWLOntology, import_declaration: OWLImportsDeclaration):
         """
         Args:
             ontology: The ontology to which the change is to be applied.
@@ -63,7 +63,7 @@ class AddImport(OWLOntologyChange):
         return self._declaration
 
 
-class OntologyManager(OWLOntologyManager):
+class OntologyManager(AbstractOWLOntologyManager):
     __slots__ = '_world'
 
     _world: owlready2.namespace.World
@@ -96,7 +96,7 @@ class OntologyManager(OWLOntologyManager):
             path_iri=path
         return Ontology(self, path_iri, load=True)
 
-    def apply_change(self, change: OWLOntologyChange):
+    def apply_change(self, change: AbstractOWLOntologyChange):
         if isinstance(change, AddImport):
             ont_x: owlready2.namespace.Ontology = self._world.get_ontology(
                 change.get_ontology().get_ontology_id().get_ontology_iri().as_str())
@@ -112,7 +112,7 @@ class OntologyManager(OWLOntologyManager):
         self._world.save()
 
 
-class SyncOntologyManager(OWLOntologyManager):
+class SyncOntologyManager(AbstractOWLOntologyManager):
 
     # WARN: Do not move local imports to top of the module
     def __init__(self):
@@ -134,5 +134,5 @@ class SyncOntologyManager(OWLOntologyManager):
     def get_owlapi_manager(self):
         return self.owlapi_manager
 
-    def apply_change(self, change: OWLOntologyChange):
+    def apply_change(self, change: AbstractOWLOntologyChange):
         raise NotImplementedError()

--- a/owlapy/owl_reasoner.py
+++ b/owlapy/owl_reasoner.py
@@ -21,21 +21,21 @@ from owlapy.owl_data_ranges import OWLDataRange, OWLDataComplementOf, OWLDataUni
 from owlapy.owl_datatype import OWLDatatype
 from owlapy.owl_object import OWLEntity
 from owlapy.owl_ontology import Ontology, _parse_concept_to_owlapy, SyncOntology
-from owlapy.abstracts.abstract_owl_ontology import OWLOntology
+from owlapy.abstracts.abstract_owl_ontology import AbstractOWLOntology
 from owlapy.owl_ontology_manager import SyncOntologyManager
 from owlapy.owl_property import OWLObjectPropertyExpression, OWLDataProperty, OWLObjectProperty, OWLObjectInverseOf, \
     OWLPropertyExpression, OWLDataPropertyExpression
 from owlapy.owl_individual import OWLNamedIndividual
 from owlapy.owl_literal import OWLLiteral
 from owlapy.utils import LRUCache
-from owlapy.abstracts.abstract_owl_reasoner import OWLReasoner, OWLReasonerEx
+from owlapy.abstracts.abstract_owl_reasoner import AbstractOWLReasoner, AbstractOWLReasonerEx
 
 logger = logging.getLogger(__name__)
 
 _P = TypeVar('_P', bound=OWLPropertyExpression)
 
 
-class OntologyReasoner(OWLReasonerEx):
+class OntologyReasoner(AbstractOWLReasonerEx):
     __slots__ = '_ontology', '_world'
     # TODO: CD: We will remove owlready2 from owlapy
     _ontology: Ontology
@@ -576,11 +576,11 @@ class OntologyReasoner(OWLReasonerEx):
     #                                            infer_data_property_values=infer_data_property_values,
     #                                            debug=debug)
 
-    def get_root_ontology(self) -> OWLOntology:
+    def get_root_ontology(self) -> AbstractOWLOntology:
         return self._ontology
 
 
-class FastInstanceCheckerReasoner(OWLReasonerEx):
+class FastInstanceCheckerReasoner(AbstractOWLReasonerEx):
     """Tries to check instances fast (but maybe incomplete)."""
     __slots__ = '_ontology', '_base_reasoner', \
                 '_ind_set', '_cls_to_ind', \
@@ -591,8 +591,8 @@ class FastInstanceCheckerReasoner(OWLReasonerEx):
                 '_negation_default', \
                 '__warned'
 
-    _ontology: OWLOntology
-    _base_reasoner: OWLReasoner
+    _ontology: AbstractOWLOntology
+    _base_reasoner: AbstractOWLReasoner
     _cls_to_ind: Dict[OWLClass, FrozenSet[OWLNamedIndividual]]  # Class => individuals
     _has_prop: Mapping[Type[_P], LRUCache[_P, FrozenSet[OWLNamedIndividual]]]  # Type => Property => individuals
     _ind_set: FrozenSet[OWLNamedIndividual]
@@ -612,7 +612,7 @@ class FastInstanceCheckerReasoner(OWLReasonerEx):
     _negation_default: bool
     _sub_properties: bool
 
-    def __init__(self, ontology: OWLOntology, base_reasoner: OWLReasoner, *,
+    def __init__(self, ontology: AbstractOWLOntology, base_reasoner: AbstractOWLReasoner, *,
                  property_cache: bool = True, negation_default: bool = True, sub_properties: bool = False):
         """Fast instance checker.
 
@@ -734,7 +734,7 @@ class FastInstanceCheckerReasoner(OWLReasonerEx):
             -> Iterable[OWLObjectPropertyExpression]:
         yield from self._base_reasoner.sub_object_properties(op=op, direct=direct)
 
-    def get_root_ontology(self) -> OWLOntology:
+    def get_root_ontology(self) -> AbstractOWLOntology:
         return self._ontology
 
     def _lazy_cache_obj_prop(self, pe: OWLObjectPropertyExpression) -> None:
@@ -1145,7 +1145,7 @@ class FastInstanceCheckerReasoner(OWLReasonerEx):
         yield from relations
 
 
-class SyncReasoner(OWLReasonerEx):
+class SyncReasoner(AbstractOWLReasonerEx):
 
     def __init__(self, ontology: Union[SyncOntology, str], reasoner="HermiT"):
         """
@@ -1662,5 +1662,5 @@ class SyncReasoner(OWLReasonerEx):
         """
         self.infer_axioms_and_save(output, output_format, ["InferredClassAssertionAxiomGenerator"])
 
-    def get_root_ontology(self) -> OWLOntology:
+    def get_root_ontology(self) -> AbstractOWLOntology:
         return self.ontology

--- a/owlapy/owlapi_mapper.py
+++ b/owlapy/owlapi_mapper.py
@@ -3,7 +3,8 @@ from typing import Iterable, TypeVar
 import jpype.imports
 
 from owlapy import owl_expression_to_manchester, manchester_to_owl_expression
-from owlapy.class_expression import OWLClassExpression, OWLDataOneOf, OWLFacetRestriction, OWLDatatypeRestriction
+from owlapy.class_expression import OWLClassExpression, OWLDataOneOf, OWLFacetRestriction, OWLDatatypeRestriction, \
+    OWLNothing, OWLClass
 from owlapy.iri import IRI
 from owlapy.owl_axiom import OWLDeclarationAxiom, OWLAnnotation, OWLAnnotationProperty, OWLClassAssertionAxiom, \
     OWLDataPropertyAssertionAxiom, OWLDataPropertyDomainAxiom, OWLDataPropertyRangeAxiom, OWLObjectPropertyDomainAxiom, \
@@ -151,6 +152,8 @@ class OWLAPIMapper:
 
     @map_.register
     def _(self, e: OWLClassExpression):
+        if isinstance(e, OWLClass) and e.str == OWLNothing.str:
+            return OWLClassImpl(self.map_(e.iri))
         return self.parser.parse(owl_expression_to_manchester(e))
 
     @map_.register(OWLAnonymousClassExpressionImpl)

--- a/owlapy/render.py
+++ b/owlapy/render.py
@@ -20,7 +20,7 @@ from owlapy.vocab import OWLFacet
 from .owl_data_ranges import OWLNaryDataRange, OWLDataComplementOf, OWLDataUnionOf, OWLDataIntersectionOf
 from .class_expression import OWLObjectHasValue, OWLFacetRestriction, OWLDatatypeRestriction, OWLObjectOneOf
 from .owl_datatype import OWLDatatype
-from .abstracts.abstract_owl_reasoner import OWLReasoner
+from .abstracts.abstract_owl_reasoner import AbstractOWLReasoner
 import requests
 import warnings
 import abc
@@ -78,7 +78,7 @@ def translating_short_form_provider(e: OWLEntity, reasoner, rules: dict[str:str]
     label_iri = "http://www.w3.org/2000/01/rdf-schema#label"
 
     def get_label(entity, r, predicate=label_iri):
-        if isinstance(r, OWLReasoner):
+        if isinstance(r, AbstractOWLReasoner):
             values = list(r.data_property_values(entity, OWLDataProperty(predicate)))
             if values:
                 return str(values[0].get_literal())


### PR DESCRIPTION
Issue #67 
- Updated naming of abstract classes in module `owlapy.abstracts`
- They now contain the "Abstract" part prior to the previous naming: eg. `OWLOntology` ==> `AbstractOWLOntology`

Issue #71 
- Fixed issue when mapping `OWLNothing` in owlapi mapper.