### PR TITLE
New methods for SyncOntology and SyncReasoner

### DIFF
--- a/owlapy/owl_axiom.py
+++ b/owlapy/owl_axiom.py
@@ -989,8 +989,8 @@ class OWLPropertyAssertionAxiom(Generic[_P, _C], OWLIndividualAxiom, metaclass=A
         return hash((self._subject, self._property, self._object, *self._annotations))
 
     def __repr__(self):
-        return f'{type(self).__name__}(subject={self._subject},property={self._property},' \
-               f'object={self._object},annotation={self._annotations})'
+        return f'{type(self).__name__}(subject={self._subject},property_={self._property},' \
+               f'object_={self._object},annotations={self._annotations})'
 
 
 class OWLObjectPropertyAssertionAxiom(OWLPropertyAssertionAxiom[OWLObjectPropertyExpression, OWLIndividual]):

--- a/owlapy/owl_ontology.py
+++ b/owlapy/owl_ontology.py
@@ -1024,6 +1024,48 @@ class SyncOntology(AbstractOWLOntology):
     def object_property_range_axioms(self, property: OWLObjectProperty) -> Iterable[OWLObjectPropertyRangeAxiom]:
         return self.mapper.map_(self.owlapi_ontology.getObjectPropertyRangeAxioms(self.mapper.map_(property)))
 
+    def _get_imports_enum(self, include_imports_closure: bool):
+        from org.semanticweb.owlapi.model.parameters import Imports
+        if include_imports_closure:
+            imports = Imports.INCLUDED
+        else:
+            imports = Imports.EXCLUDED
+        return imports
+
+    def get_signature(self, include_imports_closure: bool = True):
+        """Gets the entities that are in the signature of this ontology.
+
+        Args:
+            include_imports_closure: Whether to include/exclude imports from searches.
+
+        Returns:
+            Entities in signature.
+        """
+        return self.mapper.map_(self.owlapi_ontology.getSignature(self._get_imports_enum(include_imports_closure)))
+
+    def get_abox_axioms(self, include_imports_closure: bool = True) -> Iterable[OWLAxiom]:
+        """Get all ABox axioms.
+
+        Args:
+            include_imports_closure: Whether to include/exclude imports from searches.
+
+        Returns:
+            ABox axioms.
+        """
+
+        return self.mapper.map_(self.owlapi_ontology.getABoxAxioms(self._get_imports_enum(include_imports_closure)))
+
+    def get_tbox_axioms(self, include_imports_closure: bool = True) -> Iterable[OWLAxiom]:
+        """Get all TBox axioms.
+
+        Args:
+            include_imports_closure: Whether to include/exclude imports from searches.
+
+        Returns:
+            TBox axioms.
+        """
+        return self.mapper.map_(self.owlapi_ontology.getTBoxAxioms(self._get_imports_enum(include_imports_closure)))
+
     def get_owl_ontology_manager(self) -> _M:
         return self.manager
 

--- a/owlapy/owl_reasoner.py
+++ b/owlapy/owl_reasoner.py
@@ -1676,5 +1676,34 @@ class SyncReasoner(AbstractOWLReasonerEx):
         """
         self.infer_axioms_and_save(output, output_format, ["InferredClassAssertionAxiomGenerator"])
 
+    def is_entailed(self, axiom: OWLAxiom) -> bool:
+        """A convenience method that determines if the specified axiom is entailed by the set of reasoner axioms.
+
+        Args:
+            axiom: The axiom to check for entailment.
+
+        Return:
+            True if the axiom is entailed by the reasoner axioms and False otherwise.
+        """
+        return bool(self._owlapi_reasoner.isEntailed(self.mapper.map_(axiom)))
+
+    def is_satisfiable(self, ce: OWLClassExpression) -> bool:
+        """A convenience method that determines if the specified class expression is satisfiable with respect
+        to the reasoner axioms.
+
+        Args:
+            ce: The class expression to check for satisfiability.
+
+        Return:
+            True if the class expression is satisfiable by the reasoner axioms and False otherwise.
+        """
+
+        return bool(self._owlapi_reasoner.isSatisfiable(self.mapper.map_(ce)))
+
+    def unsatisfiable_classes(self):
+        """A convenience method that obtains the classes in the signature of the root ontology that are
+        unsatisfiable."""
+        return self.mapper.map_(self._owlapi_reasoner.unsatisfiableClasses())
+
     def get_root_ontology(self) -> AbstractOWLOntology:
         return self.ontology

--- a/owlapy/owlapi_mapper.py
+++ b/owlapy/owlapi_mapper.py
@@ -511,9 +511,8 @@ class OWLAPIMapper:
 
     @map_.register(Stream)
     def _(self, e):
-        # for en in self.to_list(e):
-        #     yield self.map_(en)
-        return self.map_(self.to_list(e))
+        for en in self.to_list(e):
+            yield self.map_(en)
 
     @staticmethod
     def to_list(stream_obj):

--- a/owlapy/owlapi_mapper.py
+++ b/owlapy/owlapi_mapper.py
@@ -511,7 +511,9 @@ class OWLAPIMapper:
 
     @map_.register(Stream)
     def _(self, e):
-        return self.to_list(e)
+        # for en in self.to_list(e):
+        #     yield self.map_(en)
+        return self.map_(self.to_list(e))
 
     @staticmethod
     def to_list(stream_obj):

--- a/tests/test_owlapy_command.py
+++ b/tests/test_owlapy_command.py
@@ -40,11 +40,11 @@ class TestOwlapyCommand(unittest.TestCase):
         reflexive_axioms = mapper.map_(
             onto.get_owlapi_ontology().getAxioms(AxiomType.REFLEXIVE_OBJECT_PROPERTY).stream())
 
-        self.assertEqual(mapper.map_(symetrical_axioms[0]),
+        self.assertEqual(list(symetrical_axioms)[0],
                          OWLSymmetricObjectPropertyAxiom(OWLObjectProperty(IRI('http://www.w3.org/2002/07/owl#',
                                                                                'topObjectProperty')), []))
 
-        self.assertEqual(mapper.map_(reflexive_axioms[0]),
+        self.assertEqual(list(reflexive_axioms)[0],
                          OWLReflexiveObjectPropertyAxiom(OWLObjectProperty(IRI('http://www.w3.org/2002/07/owl#',
                                                                                'topObjectProperty')), []))
 

--- a/tests/test_sync_ontology.py
+++ b/tests/test_sync_ontology.py
@@ -1,8 +1,9 @@
 import unittest
 
-from owlapy.class_expression import OWLClass, OWLObjectIntersectionOf, OWLObjectSomeValuesFrom
+from owlapy.class_expression import OWLClass, OWLObjectIntersectionOf, OWLObjectSomeValuesFrom, OWLObjectComplementOf
 from owlapy.iri import IRI
-from owlapy.owl_axiom import OWLEquivalentClassesAxiom
+from owlapy.owl_axiom import OWLEquivalentClassesAxiom, OWLClassAssertionAxiom, OWLObjectPropertyAssertionAxiom, \
+    OWLSubClassOfAxiom, OWLObjectPropertyRangeAxiom, OWLObjectPropertyDomainAxiom
 from owlapy.owl_individual import OWLNamedIndividual
 from owlapy.owl_ontology import OWLOntologyID
 from owlapy.owl_ontology_manager import SyncOntologyManager
@@ -69,6 +70,9 @@ S = OWLClass(IRI(NS, 'S'))
 T = OWLClass(IRI(NS, 'T'))
 U = OWLClass(IRI(NS, 'U'))
 
+father_onto_path = "KGs/Family/father.owl"
+father_manager = SyncOntologyManager()
+father_onto = father_manager.load_ontology(father_onto_path)
 
 class TestSyncReasoner(unittest.TestCase):
 
@@ -110,3 +114,39 @@ class TestSyncReasoner(unittest.TestCase):
     def test__eq__(self):
         onto2 = self.manager.load_ontology(self.ontology_path)
         self.assertTrue(self.onto.__eq__(onto2))
+
+    def test_get_signature(self):
+        self.assertCountEqual(father_onto.get_signature(),
+                              [OWLClass(IRI('http://example.com/father#', 'female')),
+                               OWLClass(IRI('http://example.com/father#', 'male')),
+                               OWLClass(IRI('http://example.com/father#', 'person')),
+                               OWLClass(IRI('http://www.w3.org/2002/07/owl#', 'Thing')),
+                               OWLObjectProperty(IRI('http://example.com/father#', 'hasChild')),
+                               OWLNamedIndividual(IRI('http://example.com/father#', 'anna')),
+                               OWLNamedIndividual(IRI('http://example.com/father#', 'heinz')),
+                               OWLNamedIndividual(IRI('http://example.com/father#', 'markus')),
+                               OWLNamedIndividual(IRI('http://example.com/father#', 'martin')),
+                               OWLNamedIndividual(IRI('http://example.com/father#', 'michelle')),
+                               OWLNamedIndividual(IRI('http://example.com/father#', 'stefan'))])
+
+    def test_get_abox(self):
+        self.assertCountEqual(father_onto.get_abox_axioms(),
+                              [OWLClassAssertionAxiom(individual=OWLNamedIndividual(IRI('http://example.com/father#', 'martin')),class_expression=OWLClass(IRI('http://example.com/father#', 'male')),annotations=[]),
+                               OWLClassAssertionAxiom(individual=OWLNamedIndividual(IRI('http://example.com/father#', 'markus')),class_expression=OWLClass(IRI('http://example.com/father#', 'male')),annotations=[]),
+                               OWLClassAssertionAxiom(individual=OWLNamedIndividual(IRI('http://example.com/father#', 'michelle')),class_expression=OWLClass(IRI('http://example.com/father#', 'female')),annotations=[]),
+                               OWLClassAssertionAxiom(individual=OWLNamedIndividual(IRI('http://example.com/father#', 'heinz')),class_expression=OWLClass(IRI('http://example.com/father#', 'male')),annotations=[]),
+                               OWLClassAssertionAxiom(individual=OWLNamedIndividual(IRI('http://example.com/father#', 'stefan')),class_expression=OWLClass(IRI('http://example.com/father#', 'male')),annotations=[]),
+                               OWLClassAssertionAxiom(individual=OWLNamedIndividual(IRI('http://example.com/father#', 'anna')),class_expression=OWLClass(IRI('http://example.com/father#', 'female')),annotations=[]),
+                               OWLObjectPropertyAssertionAxiom(subject=OWLNamedIndividual(IRI('http://example.com/father#', 'anna')),property_=OWLObjectProperty(IRI('http://example.com/father#', 'hasChild')),object_=OWLNamedIndividual(IRI('http://example.com/father#', 'heinz')),annotations=[]),
+                               OWLObjectPropertyAssertionAxiom(subject=OWLNamedIndividual(IRI('http://example.com/father#', 'stefan')),property_=OWLObjectProperty(IRI('http://example.com/father#', 'hasChild')),object_=OWLNamedIndividual(IRI('http://example.com/father#', 'markus')),annotations=[]),
+                               OWLObjectPropertyAssertionAxiom(subject=OWLNamedIndividual(IRI('http://example.com/father#', 'markus')),property_=OWLObjectProperty(IRI('http://example.com/father#', 'hasChild')),object_=OWLNamedIndividual(IRI('http://example.com/father#', 'anna')),annotations=[]),
+                               OWLObjectPropertyAssertionAxiom(subject=OWLNamedIndividual(IRI('http://example.com/father#', 'martin')),property_=OWLObjectProperty(IRI('http://example.com/father#', 'hasChild')),object_=OWLNamedIndividual(IRI('http://example.com/father#', 'heinz')),annotations=[])])
+
+    def test_get_tbox(self):
+        self.assertCountEqual(father_onto.get_tbox_axioms(),
+                              [OWLEquivalentClassesAxiom([OWLClass(IRI('http://example.com/father#', 'male')), OWLObjectComplementOf(OWLClass(IRI('http://example.com/father#', 'female')))],[]),
+                               OWLSubClassOfAxiom(sub_class=OWLClass(IRI('http://example.com/father#', 'female')),super_class=OWLClass(IRI('http://example.com/father#', 'person')),annotations=[]),
+                               OWLSubClassOfAxiom(sub_class=OWLClass(IRI('http://example.com/father#', 'male')),super_class=OWLClass(IRI('http://example.com/father#', 'person')),annotations=[]),
+                               OWLSubClassOfAxiom(sub_class=OWLClass(IRI('http://example.com/father#', 'person')),super_class=OWLClass(IRI('http://www.w3.org/2002/07/owl#', 'Thing')),annotations=[]),
+                               OWLObjectPropertyRangeAxiom(OWLObjectProperty(IRI('http://example.com/father#', 'hasChild')),OWLClass(IRI('http://example.com/father#', 'person')),[]),
+                               OWLObjectPropertyDomainAxiom(OWLObjectProperty(IRI('http://example.com/father#', 'hasChild')),OWLClass(IRI('http://example.com/father#', 'person')),[])])

--- a/tests/test_sync_reasoner.py
+++ b/tests/test_sync_reasoner.py
@@ -3,7 +3,7 @@ import unittest
 
 from jpype import JDouble
 from owlapy.class_expression import OWLClass, OWLDataSomeValuesFrom, OWLObjectIntersectionOf, OWLNothing, OWLThing, \
-    OWLClassExpression
+    OWLClassExpression, OWLObjectSomeValuesFrom
 from owlapy.iri import IRI
 from owlapy.owl_axiom import OWLDisjointClassesAxiom, OWLDeclarationAxiom, OWLClassAssertionAxiom, OWLSubClassOfAxiom, \
     OWLEquivalentClassesAxiom, OWLSubDataPropertyOfAxiom, OWLSubObjectPropertyOfAxiom
@@ -351,3 +351,20 @@ class TestSyncReasoner(unittest.TestCase):
                     OWLSubObjectPropertyOfAxiom(sub_property=OWLObjectProperty(IRI('http://www.semanticweb.org/stefan/ontologies/2023/1/untitled-ontology-11#','r1')),super_property=OWLObjectProperty(IRI('http://www.w3.org/2002/07/owl#','topObjectProperty')),annotations=[]),
                     OWLSubObjectPropertyOfAxiom(sub_property=OWLObjectProperty(IRI('http://www.semanticweb.org/stefan/ontologies/2023/1/untitled-ontology-11#','r3')),super_property=OWLObjectProperty(IRI('http://www.semanticweb.org/stefan/ontologies/2023/1/untitled-ontology-11#','r4')),annotations=[]),
                     OWLSubObjectPropertyOfAxiom(sub_property=OWLObjectProperty(IRI('http://www.semanticweb.org/stefan/ontologies/2023/1/untitled-ontology-11#','r6')),super_property=OWLObjectProperty(IRI('http://www.w3.org/2002/07/owl#','topObjectProperty')),annotations=[])])
+
+    def test_entailment(self):
+        self.assertTrue(reasoner2.is_entailed(OWLSubClassOfAxiom(sub_class=OWLClass(IRI('http://www.semanticweb.org/stefan/ontologies/2023/1/untitled-ontology-11#','D')),super_class=OWLClass(IRI('http://www.semanticweb.org/stefan/ontologies/2023/1/untitled-ontology-11#','B')),annotations=[])))
+        self.assertFalse(reasoner2.is_entailed(OWLSubClassOfAxiom(sub_class=OWLClass(IRI('http://www.semanticweb.org/stefan/ontologies/2023/1/untitled-ontology-11#','B')),super_class=OWLClass(IRI('http://www.semanticweb.org/stefan/ontologies/2023/1/untitled-ontology-11#','D')),annotations=[])))
+        self.assertFalse(reasoner2.is_entailed(OWLSubClassOfAxiom(sub_class=OWLClass(IRI('http://www.semanticweb.org/stefan/ontologies/2023/1/untitled-ontology-11#','C')),super_class=OWLClass(IRI('http://www.semanticweb.org/stefan/ontologies/2023/1/untitled-ontology-11#','G')),annotations=[])))
+
+    def test_satisfiability(self):
+        ST = OWLObjectIntersectionOf([S, T])
+        LM = OWLObjectIntersectionOf([L, M])
+        r7E = OWLObjectSomeValuesFrom(property=r7, filler=E)
+        self.assertTrue(reasoner2.is_satisfiable(ST))
+        self.assertTrue(reasoner2.is_satisfiable(r7E))
+        self.assertFalse(reasoner2.is_satisfiable(LM))
+
+    def test_unsatisfiability(self):
+        self.assertEqual(list(reasoner2.unsatisfiable_classes()), [OWLNothing])
+        self.assertNotEquals(list(reasoner2.unsatisfiable_classes()), [OWLThing])


### PR DESCRIPTION
Added new methods for SyncReasoner:
- `is_entailed` &rarr; checks if an axiom is entailed by the set of reasoner axioms.
- `is_satisfiable` &rarr; cheks if a class expression is satisfiable with respect to the reasoner axioms.
- `unsatisfiable_classes` &rarr; retrieve classes that are unsatisfiable

Added new methods for SyncOntology:
- `get_signature` &rarr; retrieve all signature entities.
- `get_abox_axioms` &rarr; retrieve all ABox axioms.
- `get_tbox_axioms` &rarr; retrieve all TBox axioms.