### PR TITLE
Confusion matrix query improvements

### DIFF
--- a/owlapy/converter.py
+++ b/owlapy/converter.py
@@ -673,13 +673,13 @@ class Owl2SparqlConverter:
                     PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
                     SELECT * WHERE {{
                        {{
-                          SELECT (xsd:double(COUNT(DISTINCT {root_variable})) as ?tp) (xsd:double(({number_of_positive_examples} - COUNT(DISTINCT {root_variable}))) as ?fn) WHERE {{
+                          SELECT (COUNT(DISTINCT {root_variable}) as ?tp) (({number_of_positive_examples} - COUNT(DISTINCT {root_variable})) as ?fn) WHERE {{
                              VALUES {root_variable} {{ {positive_examples_as_str} }}
                              {graph_pattern_str}
                           }}
                        }}
                        {{
-                          SELECT DISTINCT (xsd:double(COUNT(DISTINCT {root_variable})) as ?fp) (xsd:double(({number_of_negative_examples} - COUNT(DISTINCT {root_variable}))) as ?tn) WHERE {{
+                          SELECT (COUNT(DISTINCT {root_variable}) as ?fp) (({number_of_negative_examples} - COUNT(DISTINCT {root_variable})) as ?tn) WHERE {{
                              VALUES {root_variable} {{ {negative_examples_as_str} }}
                              {graph_pattern_str}
                           }}

--- a/tests/test_owlapy_owl2sparql_converter.py
+++ b/tests/test_owlapy_owl2sparql_converter.py
@@ -434,10 +434,11 @@ FILTER NOT EXISTS {
                                                                                       named_individuals=True)
 
         sparql_results = family_rdf_graph.query(query_with_confusion_matrix)
-        self.assertEqual(float(sparql_results.bindings[0]["tp"]), 2.0)
-        self.assertEqual(float(sparql_results.bindings[0]["fn"]), 0.0)
-        self.assertEqual(float(sparql_results.bindings[0]["fp"]), 1.0)
-        self.assertEqual(float(sparql_results.bindings[0]["tn"]), 1.0)
+        print(str(sparql_results.bindings))
+        self.assertEqual(int(sparql_results.bindings[0]["tp"]), 2)
+        self.assertEqual(int(sparql_results.bindings[0]["fn"]), 0)
+        self.assertEqual(int(sparql_results.bindings[0]["fp"]), 1)
+        self.assertEqual(int(sparql_results.bindings[0]["tn"]), 1)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Removes unnecessary DISTINCT
- Returns integer values instead of double