### PR TITLE
Bug fixing & and some additional features

### DIFF
--- a/owlapy/class_expression/class_expression.py
+++ b/owlapy/class_expression/class_expression.py
@@ -84,7 +84,7 @@ class OWLObjectComplementOf(OWLBooleanClassExpression, HasOperands[OWLClassExpre
 
     _operand: OWLClassExpression
 
-    def __new__(cls, op: OWLClassExpression):
+    def __new__(cls, op: OWLClassExpression = None):
         """
         Creates a new instance or returns the operand if op is already a complement.
         """

--- a/owlapy/iri.py
+++ b/owlapy/iri.py
@@ -39,27 +39,32 @@ class IRI(OWLAnnotationSubject, OWLAnnotationValue, metaclass=_meta_IRI):
     _namespace: str
     _remainder: str
 
-    def __init__(self, namespace: Union[str, Namespaces], remainder: str=""):
+    def __init__(self, namespace: Union[str, Namespaces], remainder: str="", is_file_path=False):
         if isinstance(namespace, Namespaces):
             namespace = namespace.ns
-        else:
-            assert namespace[-1] in ("/", ":", "#"), "It should be a valid IRI based on /, :, and #"
+        elif not is_file_path:
+            assert namespace[-1] in ("/", ":", "#"), ("It should be a valid IRI based on /, :, and #. "
+                                                      "Are you saving a file? - then set is_file_path=True "
+                                                      "to overcome this assertion.")
         import sys
         # https://docs.python.org/3.2/library/sys.html?highlight=sys.intern#sys.intern
         self._namespace = sys.intern(namespace)
         self._remainder = remainder
 
     @staticmethod
-    def create(iri:str | Namespaces, remainder:str=None) -> 'IRI':
+    def create(iri:str | Namespaces, remainder:str=None, is_file_path=False) -> 'IRI':
         assert isinstance(iri, str) | isinstance(iri, Namespaces), f"Input must be a string or an instance of Namespaces. Currently, {type(iri)}"
-        if remainder is not None:
+        if is_file_path and iri != "":
+            return IRI(iri, "", is_file_path)
+        elif remainder is not None:
             assert isinstance(remainder,str), f"Reminder must be string. Currently, {type(remainder)}"
             return IRI(iri, remainder)
         else:
             assert isinstance(iri, str) and remainder is None, \
                 f"iri must be string if remainder is None. Currently, {type(iri)} and {type(remainder)}"
             # Extract reminder from input string
-            assert "/" in iri, f"Input must contain /\tCurrently, {iri}"
+            assert "/" in iri, (f"Input must contain /\tCurrently, {iri}. Are you saving a file? - then "
+                                f"set is_file_path=True to overcome this assertion.")
             # assert ":" in iri, "Input must contain :"
             assert " " not in iri, f"Input must not contain whitespace. Currently:{iri}."
             index = 1 + max(iri.rfind("/"), iri.rfind(":"), iri.rfind("#"))

--- a/owlapy/owl_hierarchy.py
+++ b/owlapy/owl_hierarchy.py
@@ -263,7 +263,7 @@ class ClassHierarchy(AbstractHierarchy[OWLClass]):
 
     def _hierarchy_down_generator(self, reasoner: AbstractOWLReasoner) -> Iterable[Tuple[OWLClass, Iterable[OWLClass]]]:
         clss = set(reasoner.get_root_ontology().classes_in_signature())
-        clss.add(OWLNothing)
+        # clss.add(OWLNothing)
         yield from ((_, reasoner.sub_classes(_, direct=True))
                     for _ in clss)
 
@@ -299,7 +299,7 @@ class ObjectPropertyHierarchy(AbstractHierarchy[OWLObjectProperty]):
     def _hierarchy_down_generator(self, reasoner: AbstractOWLReasoner) \
             -> Iterable[Tuple[OWLObjectProperty, Iterable[OWLObjectProperty]]]:
         o_props = set(reasoner.get_root_ontology().object_properties_in_signature())
-        o_props.add(OWLBottomObjectProperty)
+        # o_props.add(OWLBottomObjectProperty)
         return ((_, map(lambda _: cast(OWLObjectProperty, _),
                         filter(lambda _: isinstance(_, OWLObjectProperty),
                                reasoner.sub_object_properties(_, direct=True))))
@@ -349,7 +349,7 @@ class DatatypePropertyHierarchy(AbstractHierarchy[OWLDataProperty]):
     def _hierarchy_down_generator(self, reasoner: AbstractOWLReasoner) \
             -> Iterable[Tuple[OWLDataProperty, Iterable[OWLDataProperty]]]:
         d_props = set(reasoner.get_root_ontology().data_properties_in_signature())
-        d_props.add(OWLBottomDataProperty)
+        # d_props.add(OWLBottomDataProperty)
         return ((_, reasoner.sub_data_properties(_, direct=True))
                 for _ in d_props)
 

--- a/owlapy/owl_property.py
+++ b/owlapy/owl_property.py
@@ -129,6 +129,13 @@ class OWLObjectProperty(OWLObjectPropertyExpression, OWLProperty):
         # documented in parent
         return self.str == "http://www.w3.org/2002/07/owl#topObjectProperty"
 
+    def __eq__(self, other):
+        if isinstance(other, OWLObjectProperty):
+            return self.iri.str == other.iri.str
+
+    def __hash__(self):
+        return hash(self.iri)
+
 
 class OWLObjectInverseOf(OWLObjectPropertyExpression):
     """Represents the inverse of a property expression (ObjectInverseOf). An inverse object property expression

--- a/owlapy/owl_reasoner.py
+++ b/owlapy/owl_reasoner.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from functools import singledispatchmethod, reduce
 from itertools import chain, repeat
 from types import MappingProxyType, FunctionType
-from typing import DefaultDict, Iterable, Dict, Mapping, Set, Type, TypeVar, Optional, FrozenSet, List, Union
+from typing import DefaultDict, Iterable, Dict, Mapping, Set, Type, TypeVar, Optional, FrozenSet, Union
 
 from owlapy.class_expression import OWLClassExpression, OWLObjectSomeValuesFrom, OWLObjectUnionOf, \
     OWLObjectIntersectionOf, OWLObjectComplementOf, OWLObjectAllValuesFrom, OWLObjectOneOf, OWLObjectHasValue, \
@@ -1063,14 +1063,14 @@ class SyncReasoner(AbstractOWLReasoner):
         """
         mapped_ce = self.mapper.map_(ce)
         instances = self._owlapi_reasoner.getInstances(mapped_ce, direct)
-        flattended_instances = instances.getFlattened()
-        assert str(type(flattended_instances)) == "<java class 'java.util.LinkedHashSet'>"
-        return {self.mapper.map_(ind) for ind in flattended_instances}
+        flattened_instances = instances.getFlattened()
+        assert str(type(flattened_instances)) == "<java class 'java.util.LinkedHashSet'>"
+        return {self.mapper.map_(ind) for ind in flattened_instances}
 
     def instances(self, ce: OWLClassExpression, direct: bool = False, timeout: int = 1000):
         return run_with_timeout(self._instances, timeout, (ce, direct))
 
-    def equivalent_classes(self, ce: OWLClassExpression) -> List[OWLClassExpression]:
+    def equivalent_classes(self, ce: OWLClassExpression):
         """
         Gets the set of named classes that are equivalent to the specified class expression with
         respect to the set of reasoner axioms.
@@ -1084,12 +1084,13 @@ class SyncReasoner(AbstractOWLReasoner):
         classes = self._owlapi_reasoner.getEquivalentClasses(self.mapper.map_(ce)).getEntities()
         yield from [self.mapper.map_(cls) for cls in classes]
 
-    def disjoint_classes(self, ce: OWLClassExpression) -> List[OWLClassExpression]:
+    def disjoint_classes(self, ce: OWLClassExpression, include_bottom_entity = False):
         """
         Gets the classes that are disjoint with the specified class expression.
 
         Args:
             ce (OWLClassExpression): The class expression whose disjoint classes are to be retrieved.
+            include_bottom_entity(bool,optional): Whether to consider OWL Nothing. Defaults to False.
 
         Returns:
             Disjoint classes of the given class expression.
@@ -1097,9 +1098,13 @@ class SyncReasoner(AbstractOWLReasoner):
         if self.reasoner_name == "ELK":
             raise NotImplementedError("`getDisjointClasses` is not yet implemented for ELK!")
         classes = self._owlapi_reasoner.getDisjointClasses(self.mapper.map_(ce)).getFlattened()
-        yield from [self.mapper.map_(cls) for cls in classes]
+        if include_bottom_entity:
+            yield from [self.mapper.map_(cls) for cls in classes]
+        else:
+            yield from [self.mapper.map_(cls) for cls in classes if not cls.isBottomEntity()]
 
-    def sub_classes(self, ce: OWLClassExpression, direct=False) -> List[OWLClassExpression]:
+
+    def sub_classes(self, ce: OWLClassExpression, direct=False, include_bottom_entity = False):
         """
          Gets the set of named classes that are the strict (potentially direct) subclasses of the
          specified class expression with respect to the reasoner axioms.
@@ -1108,13 +1113,17 @@ class SyncReasoner(AbstractOWLReasoner):
              ce (OWLClassExpression): The class expression whose strict (direct) subclasses are to be retrieved.
              direct (bool, optional): Specifies if the direct subclasses should be retrieved (True) or if
                 all subclasses (descendant) classes should be retrieved (False). Defaults to False.
+             include_bottom_entity (bool, optional): Specifies if owl nothing should be returned or not.
         Returns:
             The subclasses of the given class expression depending on `direct` field.
         """
-        classes = self._owlapi_reasoner.getSubClasses(self.mapper.map_(ce), direct).getFlattened()
-        yield from [self.mapper.map_(cls) for cls in classes]
+        classes = list(self._owlapi_reasoner.getSubClasses(self.mapper.map_(ce), direct).getFlattened())
+        if include_bottom_entity:
+            yield from [self.mapper.map_(cls) for cls in classes]
+        else:
+            yield from [self.mapper.map_(cls) for cls in classes if not cls.isBottomEntity()]
 
-    def super_classes(self, ce: OWLClassExpression, direct=False) -> List[OWLClassExpression]:
+    def super_classes(self, ce: OWLClassExpression, direct=False):
         """
         Gets the stream of named classes that are the strict (potentially direct) super classes of
         the specified class expression with respect to the imports closure of the root ontology.
@@ -1192,7 +1201,7 @@ class SyncReasoner(AbstractOWLReasoner):
         yield from [self.mapper.map_(ce) for ce in
                     self._owlapi_reasoner.getObjectPropertyRanges(self.mapper.map_(p), direct).getFlattened()]
 
-    def sub_object_properties(self, p: OWLObjectProperty, direct: bool = False):
+    def sub_object_properties(self, p: OWLObjectProperty, direct: bool = False, include_bottom_entity = False):
         """Gets the stream of simplified object property expressions that are the strict (potentially direct)
         subproperties of the specified object property expression with respect to the imports closure of the root
         ontology.
@@ -1201,6 +1210,7 @@ class SyncReasoner(AbstractOWLReasoner):
             p: The object property expression whose strict (direct) subproperties are to be retrieved.
             direct: Specifies if the direct subproperties should be retrieved (True) or if the all subproperties
                 (descendants) should be retrieved (False).
+            include_bottom_entity (bool, optional): Specifies if the bottomObjectProperty should be returned.
 
         Returns:
             If direct is True, simplified object property expressions, such that for each simplified object property
@@ -1209,8 +1219,13 @@ class SyncReasoner(AbstractOWLReasoner):
             expression, P, the set of reasoner axioms entails StrictSubObjectPropertyOf(P, pe).
             If pe is equivalent to owl:bottomObjectProperty then nothing will be returned.
         """
-        yield from [self.mapper.map_(pe) for pe in
-                    self._owlapi_reasoner.getSubObjectProperties(self.mapper.map_(p), direct).getFlattened()]
+        if include_bottom_entity:
+            yield from [self.mapper.map_(pe) for pe in
+                        self._owlapi_reasoner.getSubObjectProperties(self.mapper.map_(p), direct).getFlattened()]
+        else:
+            yield from [self.mapper.map_(pe) for pe in
+                        self._owlapi_reasoner.getSubObjectProperties(self.mapper.map_(p), direct).getFlattened()
+                        if not pe.isBottomEntity()]
 
     def super_object_properties(self, p: OWLObjectProperty, direct: bool = False):
         """Gets the stream of object properties that are the strict (potentially direct) super properties of the
@@ -1228,7 +1243,7 @@ class SyncReasoner(AbstractOWLReasoner):
         yield from [self.mapper.map_(pe) for pe in
                     self._owlapi_reasoner.getSuperObjectProperties(self.mapper.map_(p), direct).getFlattened()]
 
-    def sub_data_properties(self, p: OWLDataProperty, direct: bool = False):
+    def sub_data_properties(self, p: OWLDataProperty, direct: bool = False, include_bottom_entity = False):
         """Gets the set of named data properties that are the strict (potentially direct) subproperties of the
         specified data property expression with respect to the imports closure of the root ontology.
 
@@ -1236,6 +1251,7 @@ class SyncReasoner(AbstractOWLReasoner):
             p: The data property whose strict (direct) subproperties are to be retrieved.
             direct: Specifies if the direct subproperties should be retrieved (True) or if the all subproperties
                 (descendants) should be retrieved (False).
+            include_bottom_entity: Specifies if the bottomDataProperty should be returned.
 
         Returns:
             If direct is True, each property P where the set of reasoner axioms entails DirectSubDataPropertyOf(P, pe).
@@ -1245,8 +1261,13 @@ class SyncReasoner(AbstractOWLReasoner):
         """
         if self.reasoner_name == "ELK":
             raise NotImplementedError("`getSubDataProperties` is not yet implemented by ELK!")
-        yield from [self.mapper.map_(pe) for pe in
-                    self._owlapi_reasoner.getSubDataProperties(self.mapper.map_(p), direct).getFlattened()]
+        if include_bottom_entity:
+            yield from [self.mapper.map_(pe) for pe in
+                        self._owlapi_reasoner.getSubDataProperties(self.mapper.map_(p), direct).getFlattened()]
+        else:
+            yield from [self.mapper.map_(pe) for pe in
+                        self._owlapi_reasoner.getSubDataProperties(self.mapper.map_(p), direct).getFlattened()
+                        if not pe.isBottomEntity()]
 
     def super_data_properties(self, p: OWLDataProperty, direct: bool = False):
         """Gets the stream of data properties that are the strict (potentially direct) super properties of the
@@ -1355,12 +1376,13 @@ class SyncReasoner(AbstractOWLReasoner):
         yield from [self.mapper.map_(literal) for literal in
                     self.mapper.to_list(self._owlapi_reasoner.dataPropertyValues(self.mapper.map_(e), self.mapper.map_(p)))]
 
-    def disjoint_object_properties(self, p: OWLObjectProperty):
+    def disjoint_object_properties(self, p: OWLObjectProperty, include_bottom_entity=False):
         """Gets the simplified object properties that are disjoint with the specified object property with respect
         to the set of reasoner axioms.
 
         Args:
             p: The object property whose disjoint object properties are to be retrieved.
+            include_bottom_entity(bool,optional): Whether to consider bottomObjectProperty.
 
         Returns:
             All simplified object properties e where the root ontology imports closure entails
@@ -1369,15 +1391,21 @@ class SyncReasoner(AbstractOWLReasoner):
         """
         if self.reasoner_name == "ELK":
             raise NotImplementedError("`getDisjointObjectProperties` is not yet implemented by ELK!")
-        yield from [self.mapper.map_(pe) for pe in
-                    self._owlapi_reasoner.getDisjointObjectProperties(self.mapper.map_(p)).getFlattened()]
+        if include_bottom_entity:
+            yield from [self.mapper.map_(pe) for pe in
+                        self._owlapi_reasoner.getDisjointObjectProperties(self.mapper.map_(p)).getFlattened()]
+        else:
+            yield from [self.mapper.map_(pe) for pe in
+                        self._owlapi_reasoner.getDisjointObjectProperties(self.mapper.map_(p)).getFlattened()
+                        if not pe.isBottomEntity()]
 
-    def disjoint_data_properties(self, p: OWLDataProperty):
+    def disjoint_data_properties(self, p: OWLDataProperty, include_bottom_entity=False):
         """Gets the data properties that are disjoint with the specified data property with respect
         to the set of reasoner axioms.
 
         Args:
             p: The data property whose disjoint data properties are to be retrieved.
+            include_bottom_entity(bool,optional): Whether to consider bottomDataProperty.
 
         Returns:
             All data properties e where the root ontology imports closure entails
@@ -1386,8 +1414,13 @@ class SyncReasoner(AbstractOWLReasoner):
         """
         if self.reasoner_name == "ELK":
             raise NotImplementedError("`getDisjointDataProperties` is not yet implemented by ELK!")
-        yield from [self.mapper.map_(pe) for pe in
-                    self._owlapi_reasoner.getDisjointDataProperties(self.mapper.map_(p)).getFlattened()]
+        if include_bottom_entity:
+            yield from [self.mapper.map_(pe) for pe in
+                        self._owlapi_reasoner.getDisjointDataProperties(self.mapper.map_(p)).getFlattened()]
+        else:
+            yield from [self.mapper.map_(pe) for pe in
+                        self._owlapi_reasoner.getDisjointDataProperties(self.mapper.map_(p)).getFlattened()
+                        if not pe.isBottomEntity()]
 
     def types(self, individual: OWLNamedIndividual, direct: bool = False):
         """Gets the named classes which are (potentially direct) types of the specified named individual.

--- a/owlapy/owl_reasoner.py
+++ b/owlapy/owl_reasoner.py
@@ -36,7 +36,7 @@ _P = TypeVar('_P', bound=OWLPropertyExpression)
 
 class StructuralReasoner(AbstractOWLReasoner):
     """Tries to check instances fast (but maybe incomplete)."""
-    def __init__(self, ontology: AbstractOWLOntology, *, class_cache: bool = True,
+    def __init__(self, ontology: Union[AbstractOWLOntology, str], *, class_cache: bool = True,
                  property_cache: bool = True, negation_default: bool = True, sub_properties: bool = False):
         """Fast instance checker.
 
@@ -47,6 +47,9 @@ class StructuralReasoner(AbstractOWLReasoner):
             sub_properties: Whether to take sub properties into account for the
                 :func:`StructuralReasoner.instances` retrieval.
             """
+        if isinstance(ontology, str):
+            ontology = Ontology(ontology)
+
         super().__init__(ontology)
         assert isinstance(ontology, Ontology)
         self._world: owlready2.World = ontology._world

--- a/tests/test_owlapy_command.py
+++ b/tests/test_owlapy_command.py
@@ -85,7 +85,6 @@ class TestOwlapyCommand(unittest.TestCase):
                           OWLClass(IRI('http://www.benchmark.org/family#', 'Granddaughter')),
                           OWLClass(IRI('http://www.benchmark.org/family#', 'PersonWithASibling')),
                           OWLClass(IRI('http://www.benchmark.org/family#', 'Sister')),
-                          OWLClass(IRI('http://www.w3.org/2002/07/owl#', 'Nothing')),
                           OWLClass(IRI('http://www.benchmark.org/family#', 'Grandmother')),
                           OWLClass(IRI('http://www.benchmark.org/family#', 'Daughter')),
                           OWLClass(IRI('http://www.benchmark.org/family#', 'Brother')),

--- a/tests/test_sync_reasoner.py
+++ b/tests/test_sync_reasoner.py
@@ -168,10 +168,10 @@ class TestSyncReasoner(unittest.TestCase):
         self.assertCountEqual(list(reasoner2.equivalent_classes(N)), [N, Q])
 
     def test_disjoint_classes(self):
-        self.assertCountEqual(list(reasoner2.disjoint_classes(L)), [M, OWLNothing])
+        self.assertCountEqual(list(reasoner2.disjoint_classes(L)), [M])
 
     def test_sub_classes(self):
-        self.assertCountEqual(list(reasoner2.sub_classes(P)), [O, OWLNothing])
+        self.assertCountEqual(list(reasoner2.sub_classes(P)), [O])
 
     def test_super_classes(self):
         self.assertCountEqual(list(reasoner2.super_classes(O)), [P, OWLThing])
@@ -185,7 +185,7 @@ class TestSyncReasoner(unittest.TestCase):
         self.assertCountEqual(list(reasoner2.object_property_ranges(r1, True)), [G])
 
     def test_sub_object_properties(self):
-        self.assertCountEqual(list(reasoner2.sub_object_properties(r1, False)), [r2, OWLBottomObjectProperty])
+        self.assertCountEqual(list(reasoner2.sub_object_properties(r1, False)), [r2])
         self.assertCountEqual(list(reasoner2.sub_object_properties(r1, True)), [r2])
 
     def test_super_object_properties(self):
@@ -193,7 +193,7 @@ class TestSyncReasoner(unittest.TestCase):
         self.assertCountEqual(list(reasoner2.super_object_properties(r2, True)), [r1])
 
     def test_sub_data_properties(self):
-        self.assertCountEqual(list(reasoner2.sub_data_properties(dp1, False)), [dp2, OWLBottomDataProperty])
+        self.assertCountEqual(list(reasoner2.sub_data_properties(dp1, False)), [dp2])
         self.assertCountEqual(list(reasoner2.sub_data_properties(dp1, True)), [dp2])
 
     def test_super_data_properties(self):
@@ -212,13 +212,13 @@ class TestSyncReasoner(unittest.TestCase):
         self.assertCountEqual(list(self.reasoner.data_property_values(self.d100_25, self.charge)), [OWLLiteral(0.332)])
 
     def test_disjoint_object_properties(self):
-        self.assertCountEqual(list(reasoner2.disjoint_object_properties(r5)), [r1, r2, OWLBottomObjectProperty])
-        self.assertCountEqual(list(reasoner2.disjoint_object_properties(r1)), [r5, OWLBottomObjectProperty])
-        self.assertCountEqual(list(reasoner2.disjoint_object_properties(r2)), [r5, OWLBottomObjectProperty])
+        self.assertCountEqual(list(reasoner2.disjoint_object_properties(r5)), [r1, r2])
+        self.assertCountEqual(list(reasoner2.disjoint_object_properties(r1)), [r5])
+        self.assertCountEqual(list(reasoner2.disjoint_object_properties(r2, True)), [r5, OWLBottomObjectProperty])
 
     def test_disjoint_data_properties(self):
-        self.assertCountEqual(list(reasoner2.disjoint_data_properties(dp1)), [dp3, OWLBottomDataProperty])
-        self.assertCountEqual(list(reasoner2.disjoint_data_properties(dp3)), [dp1,dp2, OWLBottomDataProperty])
+        self.assertCountEqual(list(reasoner2.disjoint_data_properties(dp1)), [dp3])
+        self.assertCountEqual(list(reasoner2.disjoint_data_properties(dp3,True)), [dp1,dp2, OWLBottomDataProperty])
 
     def test_types(self):
         self.assertCountEqual(list(reasoner2.types(c)), [I, J, K, OWLThing])


### PR DESCRIPTION
Fixed a few bugs that emerged from trying to integrate Owlapy 1.5.0 into Ontolearn.

- Implemented `__eq__` and `__hash__` for `OWLObjectProperty`
- Added a new argument `include_bottom_entity` for reasoner' methods that can potentially return bottom entity. Default set to `False`. (Avoid computational errors in Ontolearn CELs)
- Added a new argument `is_file_path` for `IRI` class. This is useful when we want to save something and bypass the strict requirements for the IRI format.
- Removed lines which added bottom entities during owl hierarchy generation
- Updated tests in accordance
- You can now also pass the path of the ontology as a string to `StructuralReasoner`, like in SyncReasoner 