### PR TITLE
Added Prototype Implementation and Examples for OWL Justification Feature

### DIFF
--- a/examples/ontology_engineering.py
+++ b/examples/ontology_engineering.py
@@ -1,9 +1,14 @@
+import jpype
+
 from owlapy.class_expression import OWLClass
 from owlapy.owl_axiom import OWLDeclarationAxiom, OWLClassAssertionAxiom
 from owlapy.owl_individual import OWLNamedIndividual
 from owlapy.owl_ontology import Ontology
 from owlapy.iri import IRI
 from owlapy.static_funcs import download_external_files
+
+
+
 # (1) Download the datasets if KGs does not exist.
 download_external_files("https://files.dice-research.org/projects/Ontolearn/KGs.zip")
 # (2) Load the father ontology.

--- a/examples/ontology_justification.py
+++ b/examples/ontology_justification.py
@@ -1,0 +1,71 @@
+import argparse
+import os
+
+from owlapy import dl_to_owl_expression, manchester_to_owl_expression
+from owlapy.iri import IRI
+from owlapy.owl_individual import OWLNamedIndividual
+from owlapy.owl_ontology import SyncOntology
+from owlapy.owl_reasoner import SyncReasoner
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Justification Example for OWL Individual-Class Reasoning")
+    parser.add_argument('--ontology_path', type=str, required=True, help='Path to the OWL ontology file.')
+    parser.add_argument('--namespace', type=str, required=True, help='Namespace (IRI prefix) of ontology.')
+    parser.add_argument('--individual_name', type=str, required=True, help='OWL individual name.')
+    parser.add_argument('--class_expression', type=str, required=True, help='Class expression to justify.')
+    parser.add_argument('--ce_syntax_choice', type=str, choices=["DL", "Manchester"], default="DL",help='Class expression syntax choice: "DL" or "Manchester". Default is "DL".'
+    )
+
+    args = parser.parse_args()
+
+    ontology_path = args.ontology_path
+    ns = args.namespace
+    individual_name = args.individual_name
+    class_expr_str = args.class_expression
+    ce_syntax_choice = args.ce_syntax_choice
+
+    print(f"Ontology Path: {ontology_path}")
+    print(f"Namespace: {ns}")
+    print(f"Individual Name: {individual_name}")
+    print(f"Class Expression: {class_expr_str}")
+    print(f"ce_syntax_choices: {ce_syntax_choice}")
+
+    def adjust_namespace(ns: str) -> str:
+        if ns.endswith(("#", "/", ":")):
+            return ns
+        else:
+            return ns + "#"
+
+    print(f"Loading ontology from: {ontology_path}")
+    print("File exists:", os.path.exists(ontology_path))
+
+    ontology = SyncOntology(ontology_path)
+    reasoner = SyncReasoner(ontology, reasoner="Pellet")
+    print("Reasoner initialized.")
+
+    target_individual = OWLNamedIndividual(IRI.create(adjust_namespace(ns) + individual_name))
+    print(f"Target Individual: {target_individual}")
+
+    if ce_syntax_choice == "DL":
+        target_class = dl_to_owl_expression(class_expr_str, adjust_namespace(ns))
+    elif ce_syntax_choice == "Manchester":
+        target_class = manchester_to_owl_expression(class_expr_str, adjust_namespace(ns))
+    else:
+        raise ValueError(f"Unsupported syntax choice please choose DL or Manchester: {args.ce_syntax_choices}")
+
+    print(f"Target Class Expression: {target_class}")
+
+    justifications = reasoner.create_justifications({target_individual}, target_class)
+    print(f"Number of justifications found: {len(justifications)}")
+
+    if not justifications:
+        print("No justifications found.")
+    else:
+        for i, justification in enumerate(justifications, 1):
+            print(f"\nJustification {i}:")
+            for ax in justification:
+                print("  ", ax)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ontology_justification.py
+++ b/tests/test_ontology_justification.py
@@ -1,0 +1,143 @@
+import unittest
+
+from parsimonious.exceptions import IncompleteParseError
+
+from owlapy.class_expression import OWLClass
+from owlapy.iri import IRI
+from owlapy.owl_axiom import OWLObjectPropertyAssertionAxiom, OWLClassAssertionAxiom, OWLSubClassOfAxiom
+from owlapy.owl_individual import OWLNamedIndividual
+from owlapy import dl_to_owl_expression, manchester_to_owl_expression
+from owlapy.owl_ontology import SyncOntology
+from owlapy.owl_property import OWLObjectProperty
+from owlapy.owl_reasoner import SyncReasoner
+
+
+class TestCreateJustifications(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ontology_path = "KGs/Family/family-benchmark_rich_background.owl"
+        cls.namespace = "http://www.benchmark.org/family#"
+        try:
+            cls.ontology = SyncOntology(cls.ontology_path)
+            cls.reasoner = SyncReasoner(cls.ontology, reasoner="Pellet")
+        except Exception as e:
+            raise RuntimeError(f"Ontology setup failed: {str(e)}")
+
+    def test_create_justifications_with_DL_syntax(self):
+        individual = OWLNamedIndividual(IRI.create(self.namespace + "F10M171"))
+        dl_expr_str = "∃ hasChild.Male"
+
+        target_class = dl_to_owl_expression(dl_expr_str, self.namespace)
+        justifications = self.reasoner.create_justifications({individual}, target_class)
+
+        self.assertIsInstance(justifications, list, "Justifications should be a list.")
+        for justification in justifications:
+            self.assertIsInstance(justification, set, "Each justification should be a set.")
+
+        # Fake individual
+        fake_individual = OWLNamedIndividual(IRI.create(self.namespace + "NonExistentPerson"))
+        justifications = self.reasoner.create_justifications({fake_individual}, target_class)
+        self.assertEqual(len(justifications), 0, "Justifications for non-existent individual should be empty.")
+
+        # Invalid DL expression
+        with self.assertRaises(IncompleteParseError, msg="Invalid DL expression should raise exception."):
+            invalid_expr = dl_to_owl_expression("invalid some Expression", self.namespace)
+            self.reasoner.create_justifications(invalid_expr, target_class)
+
+    def test_create_justifications_with_Fake_Individual_Invalid_DL_syntax(self):
+        individual = OWLNamedIndividual(IRI.create(self.namespace + "F10M171"))
+        dl_expr_str = "∃ hasChild.Male"
+        target_class = dl_to_owl_expression(dl_expr_str, self.namespace)
+
+        # Fake individual
+        fake_individual = OWLNamedIndividual(IRI.create(self.namespace + "NonExistentPerson"))
+        justifications = self.reasoner.create_justifications({fake_individual}, target_class)
+        self.assertEqual(len(justifications), 0, "Justifications for non-existent individual should be empty.")
+
+        # Invalid DL expression
+        with self.assertRaises(IncompleteParseError, msg="Invalid DL expression should raise exception."):
+            invalid_expr = dl_to_owl_expression("invalid some Expression", self.namespace)
+            self.reasoner.create_justifications(invalid_expr, target_class)
+
+
+
+    def test_create_justifications_with_Manchester_syntax(self):
+        individual = OWLNamedIndividual(IRI.create(self.namespace + "F1F2"))
+        manchester_expr_str = "hasChild some Female"
+
+        target_class = manchester_to_owl_expression(manchester_expr_str, self.namespace)
+        justifications = self.reasoner.create_justifications({individual}, target_class)
+        print(justifications)
+
+
+        self.assertIsInstance(justifications, list)
+        for justification in justifications:
+            self.assertIsInstance(justification, set)
+        self.assertCountEqual(justifications, [{
+            OWLObjectPropertyAssertionAxiom(
+                subject=OWLNamedIndividual(IRI('http://www.benchmark.org/family#', 'F1F2')),
+                property_=OWLObjectProperty(IRI('http://www.benchmark.org/family#', 'hasChild')),
+                object_=OWLNamedIndividual(IRI('http://www.benchmark.org/family#', 'F1F3')),
+                annotations=[]), OWLClassAssertionAxiom(
+                individual=OWLNamedIndividual(IRI('http://www.benchmark.org/family#', 'F1F3')),
+                class_expression=OWLClass(IRI('http://www.benchmark.org/family#', 'Female')),
+                annotations=[])}, {OWLObjectPropertyAssertionAxiom(
+            subject=OWLNamedIndividual(IRI('http://www.benchmark.org/family#', 'F1F2')),
+            property_=OWLObjectProperty(IRI('http://www.benchmark.org/family#', 'hasChild')),
+            object_=OWLNamedIndividual(IRI('http://www.benchmark.org/family#', 'F1F3')),
+            annotations=[]), OWLClassAssertionAxiom(
+            individual=OWLNamedIndividual(IRI('http://www.benchmark.org/family#', 'F1F3')),
+            class_expression=OWLClass(IRI('http://www.benchmark.org/family#', 'Mother')),
+            annotations=[]), OWLSubClassOfAxiom(
+            sub_class=OWLClass(IRI('http://www.benchmark.org/family#', 'Mother')),
+            super_class=OWLClass(IRI('http://www.benchmark.org/family#', 'Female')),
+            annotations=[])}, {OWLSubClassOfAxiom(
+            sub_class=OWLClass(IRI('http://www.benchmark.org/family#', 'Daughter')),
+            super_class=OWLClass(IRI('http://www.benchmark.org/family#', 'Female')),
+            annotations=[]), OWLObjectPropertyAssertionAxiom(
+            subject=OWLNamedIndividual(IRI('http://www.benchmark.org/family#', 'F1F2')),
+            property_=OWLObjectProperty(IRI('http://www.benchmark.org/family#', 'hasChild')),
+            object_=OWLNamedIndividual(IRI('http://www.benchmark.org/family#', 'F1F3')),
+            annotations=[]), OWLClassAssertionAxiom(
+            individual=OWLNamedIndividual(IRI('http://www.benchmark.org/family#', 'F1F3')),
+            class_expression=OWLClass(IRI('http://www.benchmark.org/family#', 'Daughter')),
+            annotations=[])}])
+
+    def test_create_justifications_with_Fake_Individual_Invalid_Manchester_syntax(self):
+        individual = OWLNamedIndividual(IRI.create(self.namespace + "F10M171"))
+        manchester_expr_str = "hasChild some Male"
+        target_class = manchester_to_owl_expression(manchester_expr_str, self.namespace)
+
+        # Fake individual
+        fake_individual = OWLNamedIndividual(IRI.create(self.namespace + "Ghost123"))
+        justifications = self.reasoner.create_justifications({fake_individual}, target_class)
+        self.assertEqual(len(justifications), 0)
+
+        # Invalid Manchester expression
+        invalid_expr = manchester_to_owl_expression("invalid some Expression", self.namespace)
+        justifications = self.reasoner.create_justifications({individual}, invalid_expr)
+        self.assertEqual(len(justifications), 0, "Justifications for non-existent individual should be empty.")
+
+    def test_create_justifications_empty_inputs(self):
+
+        with self.assertRaises(ValueError):
+            self.reasoner.create_justifications(None, None)
+
+        with self.assertRaises(ValueError):
+            self.reasoner.create_justifications(set(), None)
+
+    def test_multiple_individuals_and_mixed_results(self):
+        valid_individual = OWLNamedIndividual(IRI.create(self.namespace + "F10M171"))
+        fake_individual = OWLNamedIndividual(IRI.create(self.namespace + "Ghost"))
+
+        class_expr = dl_to_owl_expression("∃ hasChild.Male", self.namespace)
+        justifications = self.reasoner.create_justifications({valid_individual, fake_individual}, class_expr)
+
+        self.assertIsInstance(justifications, list)
+        for justification in justifications:
+            self.assertIsInstance(justification, set)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces a prototype implementation of the create_justification method to support justification generation for OWL ontologies.

- Initial implementation of the create_justification method for generating minimal justifications (explanations) for entailments.
- Added test and example files demonstrating usage and validating correctness.
