### PR TITLE
dspy made optional

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e '.[dev]'
+        pip install -e '.[all]'
         pip install dicee[dev]
         pip install sphinx sphinx_rtd_theme sphinx-autoapi sphinx-theme sphinxcontrib-plantuml plantuml-local-client myst-parser
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e '.[dev]'
+          pip install -e '.[all]'
           pip install dicee[dev]
       - name: Lint with ruff
         run: |

--- a/README.md
+++ b/README.md
@@ -185,6 +185,26 @@ Our latest feature employees a combination of state-of-the-art approaches to ext
 text using Large Language Models (LLMs). The algorithm consist of an agentic pipeline called AGen-KG (stands for agent-generated KG)
 which can scale to large documents through chunking and merging strategies.
 
+#### Installation
+
+Before using this feature, install the required extra dependencies for LLM-based 
+ontology generation:
+
+```shell
+pip install owlapy[agentic]  # or: pip install owlapy[all]
+```
+
+If you already have the minimum version of OWLAPY installed, you can install DSPy directly:
+
+```shell
+pip install dspy
+```
+
+> **Note:** DSPy is updated frequently and compatibility with the latest versions is not guaranteed. The last verified compatible version is **3.1.3**.
+
+
+#### Example
+
 ```python
 from owlapy.agen_kg import AGenKG
 from owlapy.owl_ontology import SyncOntology

--- a/docs/usage/ontologies.md
+++ b/docs/usage/ontologies.md
@@ -190,10 +190,32 @@ created in the same directory as the file you are running this code.
 
 
 ## Generate Ontology From Text
-In OWLAPY, you’ll find a module named agen_kg (short for "agent-generated knowledge graph") that enables you to 
-extract ontologies from unstructured text using Large Language Models (LLMs).
-This functionality is built on using [DSPy](https://dspy.ai/). To use it, you need to create an instance of the `AGenKG` class, 
-where you can configure general LLM settings. Once initialized, the instance can be used as a callable object to generate an ontology, as shown below:
+
+OWLAPY includes a module named `agen_kg` (short for **"agent-generated knowledge graph"**) 
+that enables ontology extraction from unstructured text using **Large Language Models (LLMs)**. 
+This functionality is powered by [DSPy](https://dspy.ai/).
+
+To use it, create an instance of the `AGenKG` class, where you can configure your LLM 
+settings. Once initialized, the instance can be invoked as a callable to generate an ontology.
+
+### Installation
+
+Before using this feature, install the required extra dependencies for LLM-based 
+ontology generation:
+
+```shell
+pip install owlapy[agentic]  # or: pip install owlapy[all]
+```
+
+If you already have the minimum version of OWLAPY installed, you can install DSPy directly:
+
+```shell
+pip install dspy
+```
+
+> **Note:** DSPy is updated frequently and compatibility with the latest versions is not guaranteed. The last verified compatible version is **3.1.3**.
+
+### Example
 
 ```python
 from owlapy.agen_kg import AGenKG
@@ -256,7 +278,6 @@ However, you can still load an ontology to a specific world using the method `lo
 
 It is essential to associate an ontology with a reasoner, which enables the inference of new knowledge through ontology
 reasoning. In the next guide, we will explore how to use a reasoner in Owlapy.
-
 
 
 

--- a/owlapy/agen_kg/agent.py
+++ b/owlapy/agen_kg/agent.py
@@ -1,4 +1,8 @@
-import dspy
+
+try:
+    import dspy
+except ImportError:
+    raise ImportError("dspy is required for AGenKG. Please install it using 'pip install dspy'")
 from owlapy.agen_kg.graph_extracting_models import (OpenGraphExtractor, DomainGraphExtractor)
 
 class AGenKG:

--- a/owlapy/agen_kg/graph_extracting_models/domain_graph_extractor.py
+++ b/owlapy/agen_kg/graph_extracting_models/domain_graph_extractor.py
@@ -1,6 +1,9 @@
 from typing import List, Union, Optional
 import os
-import dspy
+try:
+    import dspy
+except ImportError:
+    raise ImportError("dspy is required for DomainGraphExtractor. Please install it using 'pip install dspy'")
 import uuid
 from pathlib import Path
 

--- a/owlapy/agen_kg/graph_extracting_models/open_graph_extractor.py
+++ b/owlapy/agen_kg/graph_extracting_models/open_graph_extractor.py
@@ -1,6 +1,9 @@
 from typing import List, Union
 import os
-import dspy
+try:
+    import dspy
+except ImportError:
+    raise ImportError("dspy is required for OpenGraphExtractor. Please install it using 'pip install dspy'")
 import uuid
 from pathlib import Path
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ _deps = [
     "uvicorn>=0.32.1",
     "dicee==0.3.2",
     "litserve>=0.2.0",
-    "dspy==3.0.3",
+    "dspy>=3.0.3",
     "ruff>=0.7.2",
     "pytest>=8.1.1",
 ]
@@ -44,7 +44,9 @@ extras["min"] = deps_list(
     "dspy",
 )
 
-extras["dev"] = (extras["min"] + deps_list("pytest", "ruff", "dicee"))
+extras["dev"] = (extras["min"] + deps_list("pytest", "ruff"))
+extras["agentic"] = (extras["min"] + deps_list("dspy"))
+extras["all"] = (extras["dev"] + deps_list("dspy", "dicee"))
 install_requires = [extras["min"]]
 
 with open('README.md', 'r') as fh:


### PR DESCRIPTION
dspy library is now made optional #197 
- 2 optional installation added: [agentic] - installs dspy + min, and [all] - installs everything. All modes: [min] (default), [dev], [agentic], [all]
- added installation instruction for the usage of AGenKG