### PR TITLE
Fix #212: Incorrect SPARQL translation for OWLDataSomeValuesFrom with rdfs:Literal

### DIFF
--- a/owlapy/converter.py
+++ b/owlapy/converter.py
@@ -270,7 +270,10 @@ class Owl2SparqlConverter:
         # the exclusion of "?x ?p ?o" results in the group graph pattern to just return true or false (not bindings)
         # as a result, we need to comment out the if-clause of the following line
         # if not self.in_intersection and self.modal_depth == 1:
-        self.append_triple(subject, self.mapping.new_individual_variable(), self.mapping.new_individual_variable())
+        # However, if the complement is directly inside an intersection at the top level,
+        # the intersection already provides bindings, so we don't need the extra triple pattern
+        if not (len(self.parent) > 0 and isinstance(self.parent[-1], OWLObjectIntersectionOf) and self.modal_depth == 1):
+            self.append_triple(subject, self.mapping.new_individual_variable(), self.mapping.new_individual_variable())
 
         self.append("FILTER NOT EXISTS { ")
         # process the concept after the ¬
@@ -555,7 +558,7 @@ class Owl2SparqlConverter:
         if node != TopOWLDatatype:
             self.append(f" FILTER ( DATATYPE ( {self.current_variable} ) = <{node.to_string_id()}> ) ")
         else:
-            self.append(f" FILTER ( isLiteral ( {self.current_variable} ) ")
+            self.append(f" FILTER ( isLiteral ( {self.current_variable} ) ) ")
 
     @process.register
     def _(self, node: OWLDataOneOf):

--- a/tests/test_owlapy_owl2sparql_converter.py
+++ b/tests/test_owlapy_owl2sparql_converter.py
@@ -426,5 +426,44 @@ FILTER NOT EXISTS {
         self.assertEqual(int(sparql_results.bindings[0]["fp"]), 1)
         self.assertEqual(int(sparql_results.bindings[0]["tn"]), 1)
 
+    def test_DataSomeValuesFrom_with_TopOWLDatatype_in_Complement(self):
+        """Test for issue #212: Incorrect SPARQL translation for OWLDataSomeValuesFrom with rdfs:Literal"""
+        from owlapy.class_expression import OWLClass, OWLObjectIntersectionOf, OWLObjectComplementOf, OWLDataSomeValuesFrom
+        from owlapy.owl_property import OWLDataProperty
+        from owlapy.owl_literal import TopOWLDatatype
+        
+        # Create ((CONTEXT_POSITION_MARKER ⊓ ∃mouse_lymph.Literal) ⊓ ¬∃salmonella.Literal)
+        ce = OWLObjectIntersectionOf((
+            OWLObjectIntersectionOf((
+                OWLClass(IRI('http://owlapy.internal/', 'CONTEXT_POSITION_MARKER')),
+                OWLDataSomeValuesFrom(
+                    property=OWLDataProperty(IRI('http://dl-learner.org/carcinogenesis#', 'mouse_lymph')),
+                    filler=TopOWLDatatype
+                )
+            )),
+            OWLObjectComplementOf(
+                OWLDataSomeValuesFrom(
+                    property=OWLDataProperty(IRI('http://dl-learner.org/carcinogenesis#', 'salmonella')),
+                    filler=TopOWLDatatype
+                )
+            )
+        ))
+
+        converter = Owl2SparqlConverter()
+        result = converter.convert('?pos', ce, True, False)
+        sparql = "".join(result)
+        
+        # Verify the SPARQL is valid and doesn't contain the incorrect ?pos ?s_X ?s_Y pattern
+        # The bug was producing: ?pos ?s_2 ?s_3 . between the two FILTER statements
+        self.assertNotIn('?pos ?s_2 ?s_3', sparql)
+        
+        # Verify the correct patterns are present
+        self.assertIn('?pos a <http://owlapy.internal/CONTEXT_POSITION_MARKER>', sparql)
+        self.assertIn('?pos <http://dl-learner.org/carcinogenesis#mouse_lymph>', sparql)
+        self.assertIn('FILTER ( isLiteral ( ?s_1 ) )', sparql)
+        self.assertIn('FILTER NOT EXISTS', sparql)
+        self.assertIn('<http://dl-learner.org/carcinogenesis#salmonella>', sparql)
+        self.assertIn('FILTER ( isLiteral ( ?s_2 ) )', sparql)  # Inside the FILTER NOT EXISTS
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #212

## Changes
- Fixed missing closing parenthesis in TopOWLDatatype FILTER statement
- Fixed extra triple pattern generation in OWLObjectComplementOf when inside intersection at modal depth 1
- Added regression test to prevent future occurrences

## Testing
✅ All 8 SPARQL converter tests pass
✅ All 50 extended converter tests pass
✅ New regression test included