### PR TITLE
feat: Add support for rdfs:label and rdfs:comment annotations in the ontology generation pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- The ontology generation pipeline now supports:
+  - `rdfs:label` annotations, deterministically computed from entity IRIs
+  - `rdfs:comment` annotations, generated via LLM
+
 ## [1.6.5] - 2026-05-26
 
 ### Added

--- a/owlapy/agen_kg/graph_extracting_models/domain_graph_extractor.py
+++ b/owlapy/agen_kg/graph_extracting_models/domain_graph_extractor.py
@@ -10,11 +10,16 @@ from pathlib import Path
 
 from owlapy.agen_kg.domain_examples_cache import DomainExamplesCache
 from owlapy.agen_kg.graph_extractor import GraphExtractor
-from owlapy.agen_kg.helper import extract_hierarchy_from_dbpedia, task_example_mapping
+from owlapy.agen_kg.helper import chunked_iterator, extract_hierarchy_from_dbpedia, task_example_mapping
 from owlapy.agen_kg.signatures import Domain, DomainSpecificFewShotGenerator, Entity, Literal, SPLTriples, Triple, TypeAssertion, TypeGeneration
 from owlapy.class_expression import OWLClass
 from owlapy.iri import IRI
-from owlapy.owl_axiom import OWLClassAssertionAxiom, OWLDataPropertyAssertionAxiom, OWLObjectPropertyAssertionAxiom, OWLSubClassOfAxiom
+from owlapy.owl_axiom import (
+    OWLClassAssertionAxiom,
+    OWLDataPropertyAssertionAxiom,
+    OWLObjectPropertyAssertionAxiom,
+    OWLSubClassOfAxiom,
+)
 from owlapy.owl_individual import OWLNamedIndividual
 from owlapy.owl_ontology import Ontology
 from owlapy.owl_property import OWLDataProperty, OWLObjectProperty
@@ -65,25 +70,13 @@ class DomainGraphExtractor(GraphExtractor):
 
         # Generate new examples if not cached
         examples = {}
-        task_types = [
-            'entity_extraction',
-            'triples_extraction',
-            'type_assertion',
-            'type_generation',
-            'literal_extraction',
-            'triples_with_numeric_literals_extraction'
-        ]
+        task_types = ["entity_extraction", "triples_extraction", "type_assertion", "type_generation", "literal_extraction", "triples_with_numeric_literals_extraction"]
 
         if self.logging:
             print(f"DomainGraphExtractor: INFO :: Generating domain-specific few-shot examples for domain: {domain}")
 
         for task_type in task_types:
-            result = self.few_shot_generator(
-                domain=domain,
-                task_type=task_type,
-                num_examples=2,
-                examples_example_structure=task_example_mapping[task_type]
-            )
+            result = self.few_shot_generator(domain=domain, task_type=task_type, num_examples=2, examples_example_structure=task_example_mapping[task_type])
             examples[task_type] = result.few_shot_examples
             if self.logging:
                 print(f"DomainGraphExtractor: INFO :: Generated examples for {task_type}")
@@ -162,18 +155,22 @@ class DomainGraphExtractor(GraphExtractor):
         """
         return self.examples_cache.get_cache_file_path(domain)
 
-    def generate_ontology(self, text: Union[str, Path],
-                          domain: str = None,
-                          query: str = None,
-                          ontology_namespace=f"http://ontology.local/{uuid.uuid4()}#",
-                          entity_types: List[str] = None,
-                          generate_types=False,
-                          extract_spl_triples=False,
-                          create_class_hierarchy=False,
-                          use_chunking: bool = None,
-                          use_incremental_merging = False,
-                          fact_reassurance: bool = True,
-                          save_path="generated_ontology.owl") -> Ontology:
+    def generate_ontology(
+        self,
+        text: Union[str, Path],
+        domain: str = None,
+        query: str = None,
+        ontology_namespace=f"http://ontology.local/{uuid.uuid4()}#",
+        entity_types: List[str] = None,
+        generate_types=False,
+        extract_spl_triples=False,
+        create_class_hierarchy=False,
+        use_chunking: bool = None,
+        use_incremental_merging=False,
+        fact_reassurance: bool = True,
+        generate_rdfs_annotations: bool = False,
+        save_path="generated_ontology.owl",
+    ) -> Ontology:
         """
         Generate a domain-specific ontology from text.
 
@@ -226,13 +223,12 @@ class DomainGraphExtractor(GraphExtractor):
             if self.logging:
                 chunk_info = self.get_chunking_info(text)
                 print(f"DomainGraphExtractor: INFO :: Text will be processed in {chunk_info['num_chunks']} chunks")
-                print(f"DomainGraphExtractor: INFO :: Total chars: {chunk_info['total_chars']}, "
-                      f"Est. tokens: {chunk_info['estimated_tokens']}")
+                print(f"DomainGraphExtractor: INFO :: Total chars: {chunk_info['total_chars']}, Est. tokens: {chunk_info['estimated_tokens']}")
         else:
             chunks = [text]
 
         # Use a representative sample for domain detection
-        domain_detection_text = text[:self.auto_chunk_threshold] if len(text) > self.auto_chunk_threshold else text
+        domain_detection_text = text[: self.auto_chunk_threshold] if len(text) > self.auto_chunk_threshold else text
 
         # Step 1: Detect domain if not provided
         if domain is None:
@@ -249,12 +245,12 @@ class DomainGraphExtractor(GraphExtractor):
         generated_examples = self.generate_domain_specific_examples(domain)
 
         # Use generated examples only if user hasn't provided their own
-        examples_for_entity_extraction = generated_examples['entity_extraction']
-        examples_for_triples_extraction = generated_examples['triples_extraction']
-        examples_for_type_assertion = generated_examples['type_assertion']
-        examples_for_type_generation = generated_examples['type_generation']
-        examples_for_literal_extraction =  generated_examples['literal_extraction']
-        examples_for_spl_triples_extraction = generated_examples['triples_with_numeric_literals_extraction']
+        examples_for_entity_extraction = generated_examples["entity_extraction"]
+        examples_for_triples_extraction = generated_examples["triples_extraction"]
+        examples_for_type_assertion = generated_examples["type_assertion"]
+        examples_for_type_generation = generated_examples["type_generation"]
+        examples_for_literal_extraction = generated_examples["literal_extraction"]
+        examples_for_spl_triples_extraction = generated_examples["triples_with_numeric_literals_extraction"]
 
         # Step 3: Extract entities (from chunks if needed)
         # if self.logging:
@@ -264,14 +260,9 @@ class DomainGraphExtractor(GraphExtractor):
 
         chunk_summaries = None
         if use_chunking and len(chunks) > 1:
-            entities, chunk_summaries = self._extract_entities_from_chunks(
-                chunks, examples_for_entity_extraction, "DomainGraphExtractor",
-                task_instructions=self.entity_extraction_instructions
-            )
+            entities, chunk_summaries = self._extract_entities_from_chunks(chunks, examples_for_entity_extraction, "DomainGraphExtractor", task_instructions=self.entity_extraction_instructions)
         else:
-            entities = self.entity_extractor(text=text,
-                                             few_shot_examples=examples_for_entity_extraction,
-                                             task_instructions=self.entity_extraction_instructions).entities
+            entities = self.entity_extractor(text=text, few_shot_examples=examples_for_entity_extraction, task_instructions=self.entity_extraction_instructions).entities
 
         if self.logging:
             print(f"DomainGraphExtractor: INFO :: Generated the following entities: {entities}")
@@ -290,14 +281,10 @@ class DomainGraphExtractor(GraphExtractor):
         # Step 5: Extract triples using canonical entities (from chunks if needed)
         if use_chunking and len(chunks) > 1:
             triples = self._extract_triples_from_chunks(
-                chunks, canonical_entities, examples_for_triples_extraction,
-                "DomainGraphExtractor", chunk_summaries,
-                task_instructions=self.triple_extraction_instructions
+                chunks, canonical_entities, examples_for_triples_extraction, "DomainGraphExtractor", chunk_summaries, task_instructions=self.triple_extraction_instructions
             )
         else:
-            triples = self.triples_extractor(text=text, entities=canonical_entities,
-                                             few_shot_examples=examples_for_triples_extraction,
-                                             task_instructions=self.triple_extraction_instructions).triples
+            triples = self.triples_extractor(text=text, entities=canonical_entities, few_shot_examples=examples_for_triples_extraction, task_instructions=self.triple_extraction_instructions).triples
 
         if self.logging:
             print(f"DomainGraphExtractor: INFO :: Generated the following triples: {triples}")
@@ -312,16 +299,13 @@ class DomainGraphExtractor(GraphExtractor):
 
         # Step 6: Check coherence of the relation-normalized triples
         if fact_reassurance:
-            coherent_triples = self.check_coherence(updated_triples,
-                                                    clustering_context,
-                                                    self.fact_checking_instructions)
+            coherent_triples = self.check_coherence(updated_triples, clustering_context, self.fact_checking_instructions)
             if self.logging:
                 print(f"DomainGraphExtractor: INFO :: After coherence check, kept {len(coherent_triples)} triples")
         else:
             coherent_triples = updated_triples
             if self.logging:
                 print(f"DomainGraphExtractor: INFO :: Skipped coherence check, using all {len(coherent_triples)} triples")
-
 
         # Step 7: Create ontology and add triples
         onto = Ontology(ontology_iri=IRI.create("http://example.com/ontogen"), load=False)
@@ -341,28 +325,30 @@ class DomainGraphExtractor(GraphExtractor):
 
             if use_chunking and len(chunks) > 1:
                 type_assertions = self._extract_types_from_chunks(
-                    chunks, canonical_entities, entity_types, generate_types,
-                    examples_for_type_assertion, examples_for_type_generation,
-                    "DomainGraphExtractor", chunk_summaries,
+                    chunks,
+                    canonical_entities,
+                    entity_types,
+                    generate_types,
+                    examples_for_type_assertion,
+                    examples_for_type_generation,
+                    "DomainGraphExtractor",
+                    chunk_summaries,
                     task_instructions_assertion=self.type_assertion_instructions,
-                    task_instructions_generation=self.type_generation_instructions
+                    task_instructions_generation=self.type_generation_instructions,
                 )
             else:
                 if entity_types is not None and not generate_types:
-                    type_assertions = self.type_asserter(text=text, entities=canonical_entities,
-                                                         entity_types=entity_types,
-                                                         task_instructions=self.type_assertion_instructions,
-                                                         few_shot_examples=examples_for_type_assertion).pairs
+                    type_assertions = self.type_asserter(
+                        text=text, entities=canonical_entities, entity_types=entity_types, task_instructions=self.type_assertion_instructions, few_shot_examples=examples_for_type_assertion
+                    ).pairs
                     if self.logging:
-                        print(
-                            f"DomainGraphExtractor: INFO :: Assigned types for entities as following: {type_assertions}")
+                        print(f"DomainGraphExtractor: INFO :: Assigned types for entities as following: {type_assertions}")
                 elif generate_types:
-                    type_assertions = self.type_generator(text=text, entities=canonical_entities,
-                                                          task_instructions=self.type_generation_instructions,
-                                                          few_shot_examples=examples_for_type_generation).pairs
+                    type_assertions = self.type_generator(
+                        text=text, entities=canonical_entities, task_instructions=self.type_generation_instructions, few_shot_examples=examples_for_type_generation
+                    ).pairs
                     if self.logging:
-                        print(
-                            f"DomainGraphExtractor: INFO :: Finished generating types and assigned them to entities as following: {type_assertions}")
+                        print(f"DomainGraphExtractor: INFO :: Finished generating types and assigned them to entities as following: {type_assertions}")
 
             # Cluster types and update type assertions programmatically
             types = list(set([pair[1] for pair in type_assertions]))
@@ -387,14 +373,9 @@ class DomainGraphExtractor(GraphExtractor):
         if extract_spl_triples:
             # Extract literals (from chunks if needed)
             if use_chunking and len(chunks) > 1:
-                literals = self._extract_literals_from_chunks(
-                    chunks, examples_for_literal_extraction, "DomainGraphExtractor",
-                    task_instructions=self.literal_extraction_instructions
-                )
+                literals = self._extract_literals_from_chunks(chunks, examples_for_literal_extraction, "DomainGraphExtractor", task_instructions=self.literal_extraction_instructions)
             else:
-                literals = self.literal_extractor(text=text,
-                                                  task_instructions=self.literal_extraction_instructions,
-                                                  few_shot_examples=examples_for_literal_extraction).l_values
+                literals = self.literal_extractor(text=text, task_instructions=self.literal_extraction_instructions, few_shot_examples=examples_for_literal_extraction).l_values
 
             if self.logging:
                 print(f"DomainGraphExtractor: INFO :: Generated the following numeric literals: {literals}")
@@ -402,16 +383,16 @@ class DomainGraphExtractor(GraphExtractor):
             # Extract SPL triples (from chunks if needed)
             if use_chunking and len(chunks) > 1:
                 spl_triples = self._extract_spl_triples_from_chunks(
-                    chunks, canonical_entities, literals,
-                    examples_for_spl_triples_extraction,
-                    "DomainGraphExtractor",
-                    task_instructions=self.triple_with_literal_extraction_instructions
+                    chunks, canonical_entities, literals, examples_for_spl_triples_extraction, "DomainGraphExtractor", task_instructions=self.triple_with_literal_extraction_instructions
                 )
             else:
-                spl_triples = self.spl_triples_extractor(text=text, entities=canonical_entities,
-                                                         numeric_literals=literals,
-                                                         task_instructions=self.triple_with_literal_extraction_instructions,
-                                                         few_shot_examples=examples_for_spl_triples_extraction).triples
+                spl_triples = self.spl_triples_extractor(
+                    text=text,
+                    entities=canonical_entities,
+                    numeric_literals=literals,
+                    task_instructions=self.triple_with_literal_extraction_instructions,
+                    few_shot_examples=examples_for_spl_triples_extraction,
+                ).triples
 
             if self.logging:
                 print(f"DomainGraphExtractor: INFO :: Generated the following s-p-l triples: {spl_triples}")
@@ -420,12 +401,9 @@ class DomainGraphExtractor(GraphExtractor):
             spl_relations = list(set([triple[1] for triple in spl_triples]))
             spl_relation_mapping = self.cluster_relations(spl_relations, clustering_context)
             # Update SPL triples with canonical relations
-            spl_triples = [(triple[0], spl_relation_mapping.get(triple[1], triple[1]), triple[2])
-                           for triple in spl_triples]
+            spl_triples = [(triple[0], spl_relation_mapping.get(triple[1], triple[1]), triple[2]) for triple in spl_triples]
             if self.logging and len(spl_relations) != len(set(spl_relation_mapping.values())):
-                print(
-                    f"DomainGraphExtractor: INFO :: After SPL relation clustering: "
-                    f"{list(set(spl_relation_mapping.values()))}")
+                print(f"DomainGraphExtractor: INFO :: After SPL relation clustering: {list(set(spl_relation_mapping.values()))}")
 
             for triple in spl_triples:
                 subject = OWLNamedIndividual(ontology_namespace + self.snake_case(triple[0]))
@@ -447,7 +425,8 @@ class DomainGraphExtractor(GraphExtractor):
                     continue
                 if self.logging:
                     print(
-                        f"DomainGraphExtractor: INFO :: For class {cls.remainder} found superclasses: {[IRI.create(s).remainder for s in superclasses]} and subclasses: {[IRI.create(s).remainder for s in subclasses]}")
+                        f"DomainGraphExtractor: INFO :: For class {cls.remainder} found superclasses: {[IRI.create(s).remainder for s in superclasses]} and subclasses: {[IRI.create(s).remainder for s in subclasses]}"
+                    )
 
                 for superclass in superclasses:
                     dbpedia_class_remainder = IRI.create(superclass).remainder
@@ -466,10 +445,41 @@ class DomainGraphExtractor(GraphExtractor):
                     except Exception:
                         pass
 
-        # Step 11: Save ontology
+        # Step 11: Add basic rdfs annotations
+        if generate_rdfs_annotations:
+            entities_meta = (
+                [(c.iri, "class") for c in onto.classes_in_signature()]
+                + [(p.iri, "property") for p in onto.properties_in_signature()]
+                + [(i.iri, "individual") for i in onto.individuals_in_signature()]
+            )
+
+            # Create and add rdfs:label annotations to the ontology
+            rdfs_label_axioms = []
+            for ent_iri, ent_type in entities_meta:
+                rdfs_label_axioms.append(self.get_rdfs_label_axiom(entity_iri=ent_iri, label=self.format_rdfs_label(label=ent_iri.remainder, is_property=(ent_type == "property"))))
+
+            if self.logging:
+                print(f"DomainGraphExtractor: INFO :: Created {len(rdfs_label_axioms)} rdfs:label annotations")
+
+            if rdfs_label_axioms:
+                onto.add_axiom(rdfs_label_axioms)
+
+            # Generate and add rdfs:comment annotations to the ontology
+            # We are chunking entities to drastically reduce risk of hallucination
+            for idx, batch in enumerate(chunked_iterator(seq=entities_meta, size=35), start=1):
+                if self.logging:
+                    print(f"DomainGraphExtractor: INFO :: Processing batch number {idx} for rdfs:comment generation")
+
+                rdfs_comment_axioms = self.generate_batch_rdfs_comment_axioms(entities_meta=batch, context=clustering_context)
+
+                if self.logging:
+                    print(f"DomainGraphExtractor: INFO :: Generated {len(rdfs_comment_axioms)} rdfs:comment annotations for batch number {idx}")
+
+                onto.add_axiom(rdfs_comment_axioms)
+
+        # Step 12: Save ontology
         onto.save(path=save_path)
         if self.logging:
-            print(
-                f"DomainGraphExtractor: INFO :: Successfully saved the ontology at {os.path.join(os.getcwd(), save_path)}")
+            print(f"DomainGraphExtractor: INFO :: Successfully saved the ontology at {os.path.join(os.getcwd(), save_path)}")
 
         return onto

--- a/owlapy/agen_kg/graph_extracting_models/open_graph_extractor.py
+++ b/owlapy/agen_kg/graph_extracting_models/open_graph_extractor.py
@@ -17,7 +17,7 @@ from owlapy.agen_kg.few_shot_examples import (
     EXAMPLES_FOR_TYPE_GENERATION,
 )
 from owlapy.agen_kg.graph_extractor import GraphExtractor
-from owlapy.agen_kg.helper import extract_hierarchy_from_dbpedia
+from owlapy.agen_kg.helper import chunked_iterator, extract_hierarchy_from_dbpedia
 from owlapy.agen_kg.signatures import Entity, Literal, SPLTriples, Triple, TypeAssertion, TypeGeneration
 from owlapy.class_expression import OWLClass
 from owlapy.iri import IRI
@@ -44,23 +44,28 @@ class OpenGraphExtractor(GraphExtractor):
         self.literal_extractor = dspy.Predict(Literal)
         self.spl_triples_extractor = dspy.Predict(SPLTriples)
 
-    def generate_ontology(self, text: Union[str, Path], ontology_namespace=f"http://ontology.local/{uuid.uuid4()}#",
-                          query: str = None,
-                          entity_types: List[str] = None,
-                          generate_types=False,
-                          extract_spl_triples=False,
-                          create_class_hierarchy=False,
-                          entity_clustering=True,
-                          use_chunking: bool = None,
-                          use_incremental_merging: bool = False,
-                          examples_for_entity_extraction=EXAMPLES_FOR_ENTITY_EXTRACTION,
-                          examples_for_triples_extraction=EXAMPLES_FOR_TRIPLES_EXTRACTION,
-                          examples_for_type_assertion=EXAMPLES_FOR_TYPE_ASSERTION,
-                          examples_for_type_generation=EXAMPLES_FOR_TYPE_GENERATION,
-                          examples_for_literal_extraction=EXAMPLES_FOR_LITERAL_EXTRACTION,
-                          examples_for_spl_triples_extraction=EXAMPLES_FOR_SPL_TRIPLES_EXTRACTION,
-                          fact_reassurance=True,
-                          save_path="generated_ontology.owl") -> Ontology:
+    def generate_ontology(
+        self,
+        text: Union[str, Path],
+        ontology_namespace=f"http://ontology.local/{uuid.uuid4()}#",
+        query: str = None,
+        entity_types: List[str] = None,
+        generate_types=False,
+        extract_spl_triples=False,
+        create_class_hierarchy=False,
+        entity_clustering=True,
+        use_chunking: bool = None,
+        use_incremental_merging: bool = False,
+        examples_for_entity_extraction=EXAMPLES_FOR_ENTITY_EXTRACTION,
+        examples_for_triples_extraction=EXAMPLES_FOR_TRIPLES_EXTRACTION,
+        examples_for_type_assertion=EXAMPLES_FOR_TYPE_ASSERTION,
+        examples_for_type_generation=EXAMPLES_FOR_TYPE_GENERATION,
+        examples_for_literal_extraction=EXAMPLES_FOR_LITERAL_EXTRACTION,
+        examples_for_spl_triples_extraction=EXAMPLES_FOR_SPL_TRIPLES_EXTRACTION,
+        fact_reassurance=True,
+        generate_rdfs_annotations: bool = False,
+        save_path="generated_ontology.owl",
+    ) -> Ontology:
         """
         Generate an ontology from the given text or file.
 
@@ -114,8 +119,7 @@ class OpenGraphExtractor(GraphExtractor):
             if self.logging:
                 chunk_info = self.get_chunking_info(text)
                 print(f"OpenGraphExtractor: INFO :: Text will be processed in {chunk_info['num_chunks']} chunks")
-                print(f"OpenGraphExtractor: INFO :: Total chars: {chunk_info['total_chars']}, "
-                      f"Est. tokens: {chunk_info['estimated_tokens']}")
+                print(f"OpenGraphExtractor: INFO :: Total chars: {chunk_info['total_chars']}, Est. tokens: {chunk_info['estimated_tokens']}")
         else:
             chunks = [text]
 
@@ -126,13 +130,9 @@ class OpenGraphExtractor(GraphExtractor):
         # Step 1: Extract entities (from chunks if needed)
         chunk_summaries = None  # Will be populated during chunked extraction
         if use_chunking and len(chunks) > 1:
-            entities, chunk_summaries = self._extract_entities_from_chunks(chunks,
-                                                                           examples_for_entity_extraction,
-                                                                           task_instructions=self.entity_extraction_instructions)
+            entities, chunk_summaries = self._extract_entities_from_chunks(chunks, examples_for_entity_extraction, task_instructions=self.entity_extraction_instructions)
         else:
-            entities = self.entity_extractor(text=text,
-                                             few_shot_examples=examples_for_entity_extraction,
-                                             task_instructions=self.entity_extraction_instructions).entities
+            entities = self.entity_extractor(text=text, few_shot_examples=examples_for_entity_extraction, task_instructions=self.entity_extraction_instructions).entities
 
         if self.logging:
             print(f"GraphExtractor: INFO  :: Generated the following entities: {entities}")
@@ -153,14 +153,11 @@ class OpenGraphExtractor(GraphExtractor):
 
         # Step 3: Extract triples using canonical entities (from chunks if needed)
         if use_chunking and len(chunks) > 1:
-            triples = self._extract_triples_from_chunks(chunks, canonical_entities,
-                                                        examples_for_triples_extraction,
-                                                        chunk_summaries=chunk_summaries,
-                                                        task_instructions=self.triple_extraction_instructions)
+            triples = self._extract_triples_from_chunks(
+                chunks, canonical_entities, examples_for_triples_extraction, chunk_summaries=chunk_summaries, task_instructions=self.triple_extraction_instructions
+            )
         else:
-            triples = self.triples_extractor(text=text, entities=canonical_entities,
-                                             few_shot_examples=examples_for_triples_extraction,
-                                             task_instructions=self.triple_extraction_instructions).triples
+            triples = self.triples_extractor(text=text, entities=canonical_entities, few_shot_examples=examples_for_triples_extraction, task_instructions=self.triple_extraction_instructions).triples
 
         if self.logging:
             print(f"GraphExtractor: INFO  :: Generated the following triples: {triples}")
@@ -184,7 +181,6 @@ class OpenGraphExtractor(GraphExtractor):
             if self.logging:
                 print(f"OpenGraphExtractor: INFO :: Skipped coherence check, using all {len(coherent_triples)} triples")
 
-
         # Step 5: Create an ontology and load it with extracted triples
         onto = Ontology(ontology_iri=IRI.create("http://example.com/ontogen"), load=False)
         for triple in coherent_triples:
@@ -204,27 +200,23 @@ class OpenGraphExtractor(GraphExtractor):
             # Extract types (from chunks if needed)
             if use_chunking and len(chunks) > 1:
                 type_assertions = self._extract_types_from_chunks(
-                    chunks, canonical_entities, entity_types, generate_types,
-                    examples_for_type_assertion, examples_for_type_generation,
-                    chunk_summaries=chunk_summaries
+                    chunks, canonical_entities, entity_types, generate_types, examples_for_type_assertion, examples_for_type_generation, chunk_summaries=chunk_summaries
                 )
             else:
                 # The user has specified a preset list of types
                 if entity_types is not None and not generate_types:
-                    type_assertions = self.type_asserter(text=text, entities=canonical_entities,
-                                                         entity_types=entity_types,
-                                                         few_shot_examples=examples_for_type_assertion,
-                                                         task_instructions=self.type_assertion_instructions).pairs
+                    type_assertions = self.type_asserter(
+                        text=text, entities=canonical_entities, entity_types=entity_types, few_shot_examples=examples_for_type_assertion, task_instructions=self.type_assertion_instructions
+                    ).pairs
                     if self.logging:
                         print(f"GraphExtractor: INFO  :: Assigned types for entities as following: {type_assertions}")
                 # The user wishes to leave it to the LLM to generate and assign types
                 elif generate_types:
-                    type_assertions = self.type_generator(text=text, entities=canonical_entities,
-                                                          few_shot_examples=examples_for_type_generation,
-                                                          task_instructions=self.type_generation_instructions).pairs
+                    type_assertions = self.type_generator(
+                        text=text, entities=canonical_entities, few_shot_examples=examples_for_type_generation, task_instructions=self.type_generation_instructions
+                    ).pairs
                     if self.logging:
-                        print(
-                            f"GraphExtractor: INFO  :: Finished generating types and assigned them to entities as following: {type_assertions}")
+                        print(f"GraphExtractor: INFO  :: Finished generating types and assigned them to entities as following: {type_assertions}")
 
             # Cluster types and update type assertions programmatically
             types = list(set([pair[1] for pair in type_assertions]))
@@ -249,12 +241,9 @@ class OpenGraphExtractor(GraphExtractor):
         if extract_spl_triples:
             # Extract literals (from chunks if needed)
             if use_chunking and len(chunks) > 1:
-                literals = self._extract_literals_from_chunks(chunks, examples_for_literal_extraction,
-                                                              task_instructions=self.literal_extraction_instructions)
+                literals = self._extract_literals_from_chunks(chunks, examples_for_literal_extraction, task_instructions=self.literal_extraction_instructions)
             else:
-                literals = self.literal_extractor(text=text,
-                                                  few_shot_examples=examples_for_literal_extraction,
-                                                  task_instructions=self.literal_extraction_instructions).l_values
+                literals = self.literal_extractor(text=text, few_shot_examples=examples_for_literal_extraction, task_instructions=self.literal_extraction_instructions).l_values
 
             if self.logging:
                 print(f"GraphExtractor: INFO  :: Generated the following numeric literals: {literals}")
@@ -262,14 +251,16 @@ class OpenGraphExtractor(GraphExtractor):
             # Extract SPL triples (from chunks if needed)
             if use_chunking and len(chunks) > 1:
                 spl_triples = self._extract_spl_triples_from_chunks(
-                    chunks, canonical_entities, literals, examples_for_spl_triples_extraction,
-                    task_instructions=self.triple_with_literal_extraction_instructions
+                    chunks, canonical_entities, literals, examples_for_spl_triples_extraction, task_instructions=self.triple_with_literal_extraction_instructions
                 )
             else:
-                spl_triples = self.spl_triples_extractor(text=text, entities=canonical_entities,
-                                                         numeric_literals=literals,
-                                                         few_shot_examples=examples_for_spl_triples_extraction,
-                                                         task_instructions=self.triple_with_literal_extraction_instructions).triples
+                spl_triples = self.spl_triples_extractor(
+                    text=text,
+                    entities=canonical_entities,
+                    numeric_literals=literals,
+                    few_shot_examples=examples_for_spl_triples_extraction,
+                    task_instructions=self.triple_with_literal_extraction_instructions,
+                ).triples
 
             if self.logging:
                 print(f"GraphExtractor: INFO  :: Generated the following s-p-l triples: {spl_triples}")
@@ -278,11 +269,9 @@ class OpenGraphExtractor(GraphExtractor):
             spl_relations = list(set([triple[1] for triple in spl_triples]))
             spl_relation_mapping = self.cluster_relations(spl_relations, clustering_context)
             # Update SPL triples with canonical relations
-            spl_triples = [(triple[0], spl_relation_mapping.get(triple[1], triple[1]), triple[2])
-                           for triple in spl_triples]
+            spl_triples = [(triple[0], spl_relation_mapping.get(triple[1], triple[1]), triple[2]) for triple in spl_triples]
             if self.logging and len(spl_relations) != len(set(spl_relation_mapping.values())):
-                print(
-                    f"GraphExtractor: INFO  :: After SPL relation clustering: {list(set(spl_relation_mapping.values()))}")
+                print(f"GraphExtractor: INFO  :: After SPL relation clustering: {list(set(spl_relation_mapping.values()))}")
 
             for triple in spl_triples:
                 subject = OWLNamedIndividual(ontology_namespace + self.snake_case(triple[0]))
@@ -303,7 +292,8 @@ class OpenGraphExtractor(GraphExtractor):
                     continue
                 if self.logging:
                     print(
-                        f"GraphExtractor: INFO  :: For class {cls.remainder} found superclasses: {[IRI.create(s).remainder for s in superclasses]} and subclasses: {[IRI.create(s).remainder for s in subclasses]}")
+                        f"GraphExtractor: INFO  :: For class {cls.remainder} found superclasses: {[IRI.create(s).remainder for s in superclasses]} and subclasses: {[IRI.create(s).remainder for s in subclasses]}"
+                    )
 
                 for superclass in superclasses:
                     dbpedia_class_remainder = IRI.create(superclass).remainder
@@ -321,6 +311,37 @@ class OpenGraphExtractor(GraphExtractor):
                         onto.add_axiom(ax)
                     except Exception:
                         pass
+
+        if generate_rdfs_annotations:
+            entities_meta = (
+                [(c.iri, "class") for c in onto.classes_in_signature()]
+                + [(p.iri, "property") for p in onto.properties_in_signature()]
+                + [(i.iri, "individual") for i in onto.individuals_in_signature()]
+            )
+
+            # Create and add rdfs:label annotations to the ontology
+            rdfs_label_axioms = []
+            for ent_iri, ent_type in entities_meta:
+                rdfs_label_axioms.append(self.get_rdfs_label_axiom(entity_iri=ent_iri, label=self.format_rdfs_label(label=ent_iri.remainder, is_property=(ent_type == "property"))))
+
+            if self.logging:
+                print(f"GraphExtractor: INFO :: Created {len(rdfs_label_axioms)} rdfs:label annotations")
+
+            if rdfs_label_axioms:
+                onto.add_axiom(rdfs_label_axioms)
+
+            # Generate and add rdfs:comment annotations to the ontology
+            # We are chunking entities to drastically reduce risk of hallucination
+            for idx, batch in enumerate(chunked_iterator(seq=entities_meta, size=35), start=1):
+                if self.logging:
+                    print(f"GraphExtractor: INFO :: Processing batch number {idx} for rdfs:comment generation")
+
+                rdfs_comment_axioms = self.generate_batch_rdfs_comment_axioms(entities_meta=batch, context=clustering_context)
+
+                if self.logging:
+                    print(f"GraphExtractor: INFO :: Generated {len(rdfs_comment_axioms)} rdfs:comment annotations for batch number {idx}")
+
+                onto.add_axiom(rdfs_comment_axioms)
 
         onto.save(path=save_path)
         if self.logging:

--- a/owlapy/agen_kg/graph_extractor.py
+++ b/owlapy/agen_kg/graph_extractor.py
@@ -2,12 +2,14 @@ import re
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Literal, Optional, Union
 
 import dspy
 
 from owlapy.agen_kg.chunking_models.simple_chunker import TextChunker
+from owlapy.agen_kg.helper import RDFS_COMMENT_IRI, RDFS_LABEL_IRI
 from owlapy.agen_kg.signatures import (
+    BatchRdfsCommentGenerator,
     ChunkSummarizer,
     CoherenceChecker,
     EntityDeduplication,
@@ -23,6 +25,12 @@ from owlapy.agen_kg.signatures import (
     TypeClusteringWithSummary,
 )
 from owlapy.agen_kg.text_loader import UniversalTextLoader
+from owlapy.iri import IRI
+from owlapy.owl_axiom import (
+    OWLAnnotation,
+    OWLAnnotationAssertionAxiom,
+    OWLAnnotationProperty,
+)
 from owlapy.owl_literal import OWLLiteral
 from owlapy.owl_ontology import Ontology
 
@@ -30,6 +38,7 @@ from owlapy.owl_ontology import Ontology
 # A compatible metaclass that combines dspy.Module's metaclass with ABCMeta
 class GraphExtractorMeta(type(dspy.Module), type(ABC)):
     """Metaclass that resolves conflicts between dspy.Module and ABC."""
+
     pass
 
 
@@ -75,6 +84,8 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
         self.entity_merger = dspy.Predict(IncrementalEntityMerger)
         self.triple_merger = dspy.Predict(IncrementalTripleMerger)
         self.type_merger = dspy.Predict(IncrementalTypeMerger)
+        # Generation of rdfs:comment annotations
+        self.batch_rdfs_comment_generator = dspy.Predict(BatchRdfsCommentGenerator)
 
         self.text_loader = UniversalTextLoader(enable_logging=enable_logging)
         # Default text chunker - can be configured via configure_chunking()
@@ -82,7 +93,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
             chunk_size=6000,  # ~1500 tokens
             overlap=300,
             strategy="paragraph",
-            enable_logging=enable_logging
+            enable_logging=enable_logging,
         )
         # Threshold for automatic chunking (in characters)
         self.auto_chunk_threshold = 4000  # ~1000 tokens
@@ -99,8 +110,8 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
     @staticmethod
     def snake_case(text):
         # Normalize whitespace and special chars
-        text = re.sub(r'[^\w\s]', '', text)  # Remove special chars
-        text = re.sub(r'\s+', '_', text.strip())  # Multiple spaces -> single underscore
+        text = re.sub(r"[^\w\s]", "", text)  # Remove special chars
+        text = re.sub(r"\s+", "_", text.strip())  # Multiple spaces -> single underscore
         return text.lower()
 
     @staticmethod
@@ -116,14 +127,54 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
             Formatted type name with capital first letter and lowercase rest.
         """
         # Normalize whitespace and special chars
-        text = re.sub(r'[^\w\s]', '', text)  # Remove special chars
-        text = re.sub(r'\s+', '_', text.strip())  # Multiple spaces -> single underscore
+        text = re.sub(r"[^\w\s]", "", text)  # Remove special chars
+        text = re.sub(r"\s+", "_", text.strip())  # Multiple spaces -> single underscore
         # Convert to lowercase first, then capitalize first letter
         text = text.lower()
         if text:
             text = text[0].upper() + text[1:]
         return text
 
+    @staticmethod
+    def format_rdfs_label(label: str, is_property: bool = False) -> str:
+        """
+        Convert a raw entity identifier into a clean rdfs:label suitable for RDF annotation.
+
+        This method normalizes the input string by removing special characters,
+        standardizing whitespace, and applying consistent casing rules. For non-property
+        labels, it produces a title-cased form with a capitalized first character and
+        lowercase remainder. For properties, it produces a fully lowercase form to
+        preserve relational readability conventions.
+
+        After normalization, underscores are replaced with spaces to produce a
+        human-readable label.
+
+        Examples:
+            - 'PERSON' -> 'Person'
+            - 'person_type' -> 'Person type'
+            - 'PERSON TYPE' -> 'Person type'
+            - is_property=True: 'has_name' -> 'has name'
+
+        Args:
+            label:
+                Raw entity identifier string.
+
+            is_property:
+                If True, formats the label as a property name (fully lowercase).
+                If False, formats it as a class/individual-style label.
+
+        Returns:
+            A cleaned rdfs:label string with:
+            - consistent casing rules applied
+            - underscores replaced with spaces
+            - improved human readability
+        """
+        if is_property:
+            formatted = label.lower()
+        else:
+            formatted = GraphExtractor.format_type_name(label)
+
+        return formatted.replace("_", " ")
 
     def plan_decompose(self, query: str):
         if query is None:
@@ -193,13 +244,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
         return self.text_loader.supported_formats
 
     def configure_chunking(
-            self,
-            chunk_size: int = None,
-            overlap: int = None,
-            strategy: str = None,
-            auto_chunk_threshold: int = None,
-            summarization_threshold: int = None,
-            max_summary_length: int = None
+        self, chunk_size: int = None, overlap: int = None, strategy: str = None, auto_chunk_threshold: int = None, summarization_threshold: int = None, max_summary_length: int = None
     ):
         """
         Configure text chunking settings for handling large documents.
@@ -234,7 +279,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
                 chunk_size=chunk_size or self.text_chunker.chunk_size,
                 overlap=overlap if overlap is not None else self.text_chunker.overlap,
                 strategy=strategy or self.text_chunker.strategy,
-                enable_logging=self.logging
+                enable_logging=self.logging,
             )
 
         if auto_chunk_threshold is not None:
@@ -247,19 +292,17 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
             self.max_summary_length = max_summary_length
 
         if self.logging:
-            print(f"{self.__class__.__name__}: INFO :: Chunking configured - "
-                  f"chunk_size={self.text_chunker.chunk_size}, "
-                  f"overlap={self.text_chunker.overlap}, "
-                  f"strategy={self.text_chunker.strategy}, "
-                  f"auto_threshold={self.auto_chunk_threshold}, "
-                  f"summarization_threshold={self.summarization_threshold}, "
-                  f"max_summary_length={self.max_summary_length}")
+            print(
+                f"{self.__class__.__name__}: INFO :: Chunking configured - "
+                f"chunk_size={self.text_chunker.chunk_size}, "
+                f"overlap={self.text_chunker.overlap}, "
+                f"strategy={self.text_chunker.strategy}, "
+                f"auto_threshold={self.auto_chunk_threshold}, "
+                f"summarization_threshold={self.summarization_threshold}, "
+                f"max_summary_length={self.max_summary_length}"
+            )
 
-    def configure_chunking_for_model(
-            self,
-            max_context_tokens: int,
-            prompt_overhead_tokens: int = 1500
-    ):
+    def configure_chunking_for_model(self, max_context_tokens: int, prompt_overhead_tokens: int = 1500):
         """
         Automatically configure chunking based on model specifications.
 
@@ -280,16 +323,11 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
             # For GPT-4-turbo (128K context)
             extractor.configure_chunking_for_model(128000, 2000)
         """
-        chunk_size = TextChunker.calculate_chunk_size_for_model(
-            max_context_tokens,
-            prompt_overhead_tokens
-        )
+        chunk_size = TextChunker.calculate_chunk_size_for_model(max_context_tokens, prompt_overhead_tokens)
         self.configure_chunking(chunk_size=chunk_size)
 
         if self.logging:
-            print(f"{self.__class__.__name__}: INFO :: Configured for model with "
-                  f"{max_context_tokens} token context window, "
-                  f"chunk_size={chunk_size} chars")
+            print(f"{self.__class__.__name__}: INFO :: Configured for model with {max_context_tokens} token context window, chunk_size={chunk_size} chars")
 
     def should_chunk_text(self, text: str) -> bool:
         """
@@ -412,11 +450,10 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
 
         # Truncate if still too long
         if len(combined) > self.max_summary_length:
-            combined = combined[:self.max_summary_length]
+            combined = combined[: self.max_summary_length]
 
         if self.logging:
-            print(
-                f"{self.__class__.__name__}: INFO :: Combined {len(chunk_summaries)} summaries into {len(combined)} chars")
+            print(f"{self.__class__.__name__}: INFO :: Combined {len(chunk_summaries)} summaries into {len(combined)} chars")
 
         return combined
 
@@ -437,13 +474,12 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
         # For small texts, use the text directly
         if not self.should_use_summarization(text):
             if len(text) > self.max_summary_length:
-                return text[:self.max_summary_length]
+                return text[: self.max_summary_length]
             return text
 
         # For large texts, generate summary
         if self.logging:
-            print(
-                f"{self.__class__.__name__}: INFO :: Text exceeds summarization threshold, generating summary for clustering")
+            print(f"{self.__class__.__name__}: INFO :: Text exceeds summarization threshold, generating summary for clustering")
 
         # Use provided chunks or create new ones
         if chunks is None:
@@ -487,8 +523,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
             if len(self._chunk_summary_cache) > self._max_cache_size:
                 self.clear_summary_cache()
 
-    def _merge_entity_lists(self, entity_lists: List[List[str]], chunk_summaries: List[str] = None,
-                            use_llm_merge: bool = None) -> List[str]:
+    def _merge_entity_lists(self, entity_lists: List[List[str]], chunk_summaries: List[str] = None, use_llm_merge: bool = None) -> List[str]:
         """
         Merge entity lists from multiple chunks, removing duplicates.
 
@@ -575,7 +610,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
                 )
 
                 # Validate result
-                if not hasattr(result, 'merged_entities') or not result.merged_entities:
+                if not hasattr(result, "merged_entities") or not result.merged_entities:
                     if self.logging:
                         print(f"{self.__class__.__name__}: WARNING :: LLM returned empty result, using simple merge")
                     raise ValueError("Empty result from LLM")
@@ -583,7 +618,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
                 merged_entities = result.merged_entities
 
                 # Update global mapping with new mappings
-                if hasattr(result, 'entity_mapping') and result.entity_mapping:
+                if hasattr(result, "entity_mapping") and result.entity_mapping:
                     for original, canonical in result.entity_mapping:
                         global_mapping[original] = canonical
 
@@ -609,8 +644,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
 
         return merged_entities
 
-    def _merge_triple_lists(self, triple_lists: List[List[tuple]], chunk_summaries: List[str] = None,
-                            use_llm_merge: bool = None) -> List[tuple]:
+    def _merge_triple_lists(self, triple_lists: List[List[tuple]], chunk_summaries: List[str] = None, use_llm_merge: bool = None) -> List[tuple]:
         """
         Merge triple lists from multiple chunks, removing duplicates.
 
@@ -689,7 +723,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
                 )
 
                 # Validate result
-                if not hasattr(result, 'merged_triples') or not result.merged_triples:
+                if not hasattr(result, "merged_triples") or not result.merged_triples:
                     if self.logging:
                         print(f"{self.__class__.__name__}: WARNING :: LLM returned empty result, using simple merge")
                     raise ValueError("Empty result from LLM")
@@ -704,8 +738,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
 
             except Exception as e:
                 if self.logging:
-                    print(
-                        f"{self.__class__.__name__}: WARNING :: LLM triple merge failed, falling back to simple merge: {e}")
+                    print(f"{self.__class__.__name__}: WARNING :: LLM triple merge failed, falling back to simple merge: {e}")
                 # Fallback to simple merge
                 seen = set((t[0].lower(), t[1].lower(), t[2].lower()) for t in merged_triples)
                 for triple in triple_lists[i]:
@@ -716,8 +749,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
 
         return merged_triples
 
-    def _merge_type_assertions(self, assertion_lists: List[List[tuple]], chunk_summaries: List[str] = None,
-                               use_llm_merge: bool = None) -> List[tuple]:
+    def _merge_type_assertions(self, assertion_lists: List[List[tuple]], chunk_summaries: List[str] = None, use_llm_merge: bool = None) -> List[tuple]:
         """
         Merge type assertion lists from multiple chunks.
 
@@ -758,8 +790,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
                     entity_types[entity_lower] = (entity, entity_type)
         return list(entity_types.values())
 
-    def _incremental_merge_type_assertions(self, assertion_lists: List[List[tuple]], chunk_summaries: List[str]) -> \
-    List[tuple]:
+    def _incremental_merge_type_assertions(self, assertion_lists: List[List[tuple]], chunk_summaries: List[str]) -> List[tuple]:
         """
         Incrementally merge type assertions using LLM to resolve conflicts.
         """
@@ -794,7 +825,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
                 )
 
                 # Validate result
-                if not hasattr(result, 'merged_types') or not result.merged_types:
+                if not hasattr(result, "merged_types") or not result.merged_types:
                     if self.logging:
                         print(f"{self.__class__.__name__}: WARNING :: LLM returned empty result, using simple merge")
                     raise ValueError("Empty result from LLM")
@@ -809,8 +840,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
 
             except Exception as e:
                 if self.logging:
-                    print(
-                        f"{self.__class__.__name__}: WARNING :: LLM type merge failed, falling back to simple merge: {e}")
+                    print(f"{self.__class__.__name__}: WARNING :: LLM type merge failed, falling back to simple merge: {e}")
                 # Fallback to simple merge
                 existing_entities = set(t[0].lower() for t in merged_types)
                 for entity, entity_type in assertion_lists[i]:
@@ -868,12 +898,11 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
             # Get or create summary for deduplication context
             clustering_context = self.get_clustering_context(text)
             if self.logging:
-                print(
-                    f"{self.__class__.__name__}: INFO :: Using summary ({len(clustering_context)} chars) for entity deduplication")
+                print(f"{self.__class__.__name__}: INFO :: Using summary ({len(clustering_context)} chars) for entity deduplication")
             result = self.entity_deduplicator_with_summary(entities=entities, summary=clustering_context)
         else:
             # Use direct text (truncated if necessary)
-            context = text[:self.max_summary_length] if len(text) > self.max_summary_length else text
+            context = text[: self.max_summary_length] if len(text) > self.max_summary_length else text
             result = self.entity_deduplicator(entities=entities, text=context)
 
         # Get the filtered entities list
@@ -914,11 +943,10 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
         if use_summary:
             clustering_context = self.get_clustering_context(text)
             if self.logging:
-                print(
-                    f"{self.__class__.__name__}: INFO :: Using summary ({len(clustering_context)} chars) for type clustering")
+                print(f"{self.__class__.__name__}: INFO :: Using summary ({len(clustering_context)} chars) for type clustering")
             result = self.type_clusterer_with_summary(types=types, summary=clustering_context)
         else:
-            context = text[:self.max_summary_length] if len(text) > self.max_summary_length else text
+            context = text[: self.max_summary_length] if len(text) > self.max_summary_length else text
             result = self.type_clusterer(types=types, text=context)
 
         type_mapping = {}
@@ -967,11 +995,10 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
         if use_summary:
             clustering_context = self.get_clustering_context(text)
             if self.logging:
-                print(
-                    f"{self.__class__.__name__}: INFO :: Using summary ({len(clustering_context)} chars) for relation clustering")
+                print(f"{self.__class__.__name__}: INFO :: Using summary ({len(clustering_context)} chars) for relation clustering")
             result = self.relation_clusterer_with_summary(relations=relations, summary=clustering_context)
         else:
-            context = text[:self.max_summary_length] if len(text) > self.max_summary_length else text
+            context = text[: self.max_summary_length] if len(text) > self.max_summary_length else text
             result = self.relation_clusterer(relations=relations, text=context)
 
         relation_mapping = {}
@@ -992,8 +1019,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
 
         return relation_mapping
 
-    def check_coherence(self, triples: List[tuple], text: str, task_instructions: str = None, batch_size: int = 50,
-                        threshold: int = 3, use_summary: bool = None) -> List[tuple]:
+    def check_coherence(self, triples: List[tuple], text: str, task_instructions: str = None, batch_size: int = 50, threshold: int = 3, use_summary: bool = None) -> List[tuple]:
         """
         Check coherence of extracted triples and filter out low-quality ones.
 
@@ -1026,21 +1052,20 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
             if self.logging:
                 print(f"{self.__class__.__name__}: INFO :: Using summary ({len(context)} chars) for coherence checking")
         else:
-            context = text[:self.max_summary_length] if len(text) > self.max_summary_length else text
+            context = text[: self.max_summary_length] if len(text) > self.max_summary_length else text
 
         coherent_triples = []
 
         # Process triples in batches
         for i in range(0, len(triples), batch_size):
-            batch = triples[i:i + batch_size]
+            batch = triples[i : i + batch_size]
             result = self.coherence_checker(triples=batch, text=context, task_instructions=task_instructions)
 
             for triple, score, explanation in result.coherence_scores:
                 if score >= threshold:
                     coherent_triples.append(triple)
                 elif self.logging:
-                    print(
-                        f"{self.__class__.__name__}: INFO :: Filtered out triple {triple} (score: {score}/5): {explanation}")
+                    print(f"{self.__class__.__name__}: INFO :: Filtered out triple {triple} (score: {score}/5): {explanation}")
 
         if self.logging:
             filtered_count = len(triples) - len(coherent_triples)
@@ -1049,14 +1074,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
 
         return coherent_triples
 
-    def _extract_entities_from_chunks(
-            self,
-            chunks: List[str],
-            examples_for_entity_extraction: str,
-            extractor_name: str = None,
-            use_llm_merge: bool = None,
-            task_instructions: str = None
-    ) -> tuple:
+    def _extract_entities_from_chunks(self, chunks: List[str], examples_for_entity_extraction: str, extractor_name: str = None, use_llm_merge: bool = None, task_instructions: str = None) -> tuple:
         """
         Extract entities from multiple text chunks and merge results.
         Generic method that works for all extractor subclasses.
@@ -1073,7 +1091,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
             Tuple of (merged_entities, chunk_summaries) where chunk_summaries can be used
             for subsequent operations.
         """
-        if not hasattr(self, 'entity_extractor'):
+        if not hasattr(self, "entity_extractor"):
             raise AttributeError(f"{self.__class__.__name__} must define 'entity_extractor'")
 
         extractor_name = extractor_name or self.__class__.__name__
@@ -1089,12 +1107,8 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
                 print(f"{extractor_name}: INFO :: Extracting entities from chunk {i + 1}/{len(chunks)}")
 
             try:
-                result = self.entity_extractor(
-                    text=chunk,
-                    few_shot_examples=examples_for_entity_extraction,
-                    task_instructions=task_instructions
-                )
-                chunk_entities = result.entities if hasattr(result, 'entities') and result.entities else []
+                result = self.entity_extractor(text=chunk, few_shot_examples=examples_for_entity_extraction, task_instructions=task_instructions)
+                chunk_entities = result.entities if hasattr(result, "entities") and result.entities else []
             except Exception as e:
                 if self.logging:
                     print(f"{extractor_name}: WARNING :: Failed to extract entities from chunk {i + 1}: {e}")
@@ -1121,14 +1135,14 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
         return merged_entities, chunk_summaries
 
     def _extract_triples_from_chunks(
-            self,
-            chunks: List[str],
-            entities: List[str],
-            examples_for_triples_extraction: str,
-            extractor_name: str = None,
-            chunk_summaries: List[str] = None,
-            use_llm_merge: bool = None,
-            task_instructions: str = None
+        self,
+        chunks: List[str],
+        entities: List[str],
+        examples_for_triples_extraction: str,
+        extractor_name: str = None,
+        chunk_summaries: List[str] = None,
+        use_llm_merge: bool = None,
+        task_instructions: str = None,
     ) -> List[tuple]:
         """
         Extract triples from multiple text chunks and merge results.
@@ -1147,7 +1161,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
         Returns:
             Merged list of triples from all chunks.
         """
-        if not hasattr(self, 'triples_extractor'):
+        if not hasattr(self, "triples_extractor"):
             raise AttributeError(f"{self.__class__.__name__} must define 'triples_extractor'")
 
         extractor_name = extractor_name or self.__class__.__name__
@@ -1166,13 +1180,8 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
                 print(f"{extractor_name}: INFO :: Extracting triples from chunk {i + 1}/{len(chunks)}")
 
             try:
-                result = self.triples_extractor(
-                    text=chunk,
-                    entities=entities,
-                    few_shot_examples=examples_for_triples_extraction,
-                    task_instructions=task_instructions
-                )
-                chunk_triples = result.triples if hasattr(result, 'triples') and result.triples else []
+                result = self.triples_extractor(text=chunk, entities=entities, few_shot_examples=examples_for_triples_extraction, task_instructions=task_instructions)
+                chunk_triples = result.triples if hasattr(result, "triples") and result.triples else []
             except Exception as e:
                 if self.logging:
                     print(f"{extractor_name}: WARNING :: Failed to extract triples from chunk {i + 1}: {e}")
@@ -1192,18 +1201,18 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
         return merged_triples
 
     def _extract_types_from_chunks(
-            self,
-            chunks: List[str],
-            entities: List[str],
-            entity_types: List[str],
-            generate_types: bool,
-            examples_for_type_assertion: str,
-            examples_for_type_generation: str,
-            extractor_name: str = None,
-            chunk_summaries: List[str] = None,
-            use_llm_merge: bool = None,
-            task_instructions_assertion: str = None,
-            task_instructions_generation: str = None
+        self,
+        chunks: List[str],
+        entities: List[str],
+        entity_types: List[str],
+        generate_types: bool,
+        examples_for_type_assertion: str,
+        examples_for_type_generation: str,
+        extractor_name: str = None,
+        chunk_summaries: List[str] = None,
+        use_llm_merge: bool = None,
+        task_instructions_assertion: str = None,
+        task_instructions_generation: str = None,
     ) -> List[tuple]:
         """
         Extract type assertions from multiple text chunks and merge results.
@@ -1226,7 +1235,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
         Returns:
             Merged list of type assertions from all chunks.
         """
-        if not hasattr(self, 'type_asserter') or not hasattr(self, 'type_generator'):
+        if not hasattr(self, "type_asserter") or not hasattr(self, "type_generator"):
             raise AttributeError(f"{self.__class__.__name__} must define 'type_asserter' and 'type_generator'")
 
         extractor_name = extractor_name or self.__class__.__name__
@@ -1246,22 +1255,11 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
 
             try:
                 if entity_types is not None and not generate_types:
-                    result = self.type_asserter(
-                        text=chunk,
-                        entities=entities,
-                        entity_types=entity_types,
-                        task_instructions = task_instructions_assertion,
-                        few_shot_examples=examples_for_type_assertion
-                    )
-                    chunk_assertions = result.pairs if hasattr(result, 'pairs') and result.pairs else []
+                    result = self.type_asserter(text=chunk, entities=entities, entity_types=entity_types, task_instructions=task_instructions_assertion, few_shot_examples=examples_for_type_assertion)
+                    chunk_assertions = result.pairs if hasattr(result, "pairs") and result.pairs else []
                 else:  # generate_types
-                    result = self.type_generator(
-                        text=chunk,
-                        entities=entities,
-                        task_instructions = task_instructions_generation,
-                        few_shot_examples=examples_for_type_generation
-                    )
-                    chunk_assertions = result.pairs if hasattr(result, 'pairs') and result.pairs else []
+                    result = self.type_generator(text=chunk, entities=entities, task_instructions=task_instructions_generation, few_shot_examples=examples_for_type_generation)
+                    chunk_assertions = result.pairs if hasattr(result, "pairs") and result.pairs else []
             except Exception as e:
                 if self.logging:
                     print(f"{extractor_name}: WARNING :: Failed to extract types from chunk {i + 1}: {e}")
@@ -1280,13 +1278,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
 
         return merged_assertions
 
-    def _extract_literals_from_chunks(
-            self,
-            chunks: List[str],
-            examples_for_literal_extraction: str,
-            extractor_name: str = None,
-            task_instructions: str = None
-    ) -> List[str]:
+    def _extract_literals_from_chunks(self, chunks: List[str], examples_for_literal_extraction: str, extractor_name: str = None, task_instructions: str = None) -> List[str]:
         """
         Extract literals from multiple text chunks and merge results.
         Generic method that works for all extractor subclasses.
@@ -1300,7 +1292,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
         Returns:
             Merged list of literals from all chunks.
         """
-        if not hasattr(self, 'literal_extractor'):
+        if not hasattr(self, "literal_extractor"):
             raise AttributeError(f"{self.__class__.__name__} must define 'literal_extractor'")
 
         extractor_name = extractor_name or self.__class__.__name__
@@ -1311,12 +1303,8 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
                 print(f"{extractor_name}: INFO :: Extracting literals from chunk {i + 1}/{len(chunks)}")
 
             try:
-                result = self.literal_extractor(
-                    text=chunk,
-                    task_instructions=task_instructions,
-                    few_shot_examples=examples_for_literal_extraction
-                )
-                chunk_literals = result.l_values if hasattr(result, 'l_values') and result.l_values else []
+                result = self.literal_extractor(text=chunk, task_instructions=task_instructions, few_shot_examples=examples_for_literal_extraction)
+                chunk_literals = result.l_values if hasattr(result, "l_values") and result.l_values else []
             except Exception as e:
                 if self.logging:
                     print(f"{extractor_name}: WARNING :: Failed to extract literals from chunk {i + 1}: {e}")
@@ -1336,13 +1324,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
         return merged_literals
 
     def _extract_spl_triples_from_chunks(
-            self,
-            chunks: List[str],
-            entities: List[str],
-            literals: List[str],
-            examples_for_spl_triples_extraction: str,
-            extractor_name: str = None,
-            task_instructions: str = None
+        self, chunks: List[str], entities: List[str], literals: List[str], examples_for_spl_triples_extraction: str, extractor_name: str = None, task_instructions: str = None
     ) -> List[tuple]:
         """
         Extract SPL triples from multiple text chunks and merge results.
@@ -1359,7 +1341,7 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
         Returns:
             Merged list of SPL triples from all chunks.
         """
-        if not hasattr(self, 'spl_triples_extractor'):
+        if not hasattr(self, "spl_triples_extractor"):
             raise AttributeError(f"{self.__class__.__name__} must define 'spl_triples_extractor'")
 
         extractor_name = extractor_name or self.__class__.__name__
@@ -1371,13 +1353,9 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
 
             try:
                 result = self.spl_triples_extractor(
-                    text=chunk,
-                    entities=entities,
-                    numeric_literals=literals,
-                    task_instructions= task_instructions,
-                    few_shot_examples=examples_for_spl_triples_extraction
+                    text=chunk, entities=entities, numeric_literals=literals, task_instructions=task_instructions, few_shot_examples=examples_for_spl_triples_extraction
                 )
-                chunk_triples = result.triples if hasattr(result, 'triples') and result.triples else []
+                chunk_triples = result.triples if hasattr(result, "triples") and result.triples else []
             except Exception as e:
                 if self.logging:
                     print(f"{extractor_name}: WARNING :: Failed to extract SPL triples from chunk {i + 1}: {e}")
@@ -1423,8 +1401,8 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
         if literal is None:
             try:
                 str_value = str(value).lower().strip()
-                if str_value in ('true', 'false'):
-                    bool_value = str_value == 'true'
+                if str_value in ("true", "false"):
+                    bool_value = str_value == "true"
                     literal = OWLLiteral(bool_value)  # OWLLiteral will auto-detect bool type
             except (ValueError, TypeError, AttributeError):
                 pass
@@ -1469,3 +1447,86 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
             Generated Ontology object.
         """
         pass
+
+    def _get_annotation_assertion_axiom(self, entity_iri: IRI, annotation_iri: IRI, value: str) -> OWLAnnotationAssertionAxiom:
+        """
+        Create a basic OWL annotation assertion axiom for a given entity.
+
+        This is an internal helper method that wraps a string value into an
+        OWLLiteral and pairs it with the specified annotation property.
+
+        Args:
+            entity_iri (IRI): The IRI of the entity being annotated.
+            annotation_iri (IRI): The IRI of the annotation property (e.g., label, comment).
+            value (str): The string literal value to be assigned to the annotation.
+
+        Returns:
+            OWLAnnotationAssertionAxiom: A constructed OWL annotation assertion.
+        """
+        annotation_value = OWLLiteral(value)
+        annotation = OWLAnnotation(OWLAnnotationProperty(annotation_iri), annotation_value)
+        return OWLAnnotationAssertionAxiom(entity_iri, annotation)
+
+    def get_rdfs_label_axiom(self, entity_iri: IRI, label: str) -> OWLAnnotationAssertionAxiom:
+        """
+        Create an RDFS label annotation assertion axiom for an entity.
+
+        Utilizes the standard RDFS label IRI (http://www.w3.org/2000/01/rdf-schema#label)
+        to assign a human-readable name to the entity.
+
+        Args:
+            entity_iri (IRI): The IRI of the entity to receive the label.
+            label (str): The text for the rdfs:label.
+
+        Returns:
+            OWLAnnotationAssertionAxiom: An annotation assertion axiom for rdfs:label.
+        """
+        return self._get_annotation_assertion_axiom(entity_iri, RDFS_LABEL_IRI, label)
+
+    def generate_batch_rdfs_comment_axioms(self, entities_meta: list[tuple[IRI, Literal["class", "property", "individual"]]], context: str) -> list[OWLAnnotationAssertionAxiom]:
+        """
+        Generate RDFS comment annotation assertion axioms for multiple OWL entities.
+
+        This method sends a batch of (entity IRI, entity type) pairs to an LLM,
+        which returns (IRI, comment) pairs. Each generated comment is wrapped
+        into an `rdfs:comment` OWL annotation assertion axiom.
+
+        Only comments for entities whose IRIs are present in `entities_meta`
+        are converted into axioms. Returned IRIs are validated against the
+        input entity IRIs after converting them to strings.
+
+        Args:
+            entities_meta:
+                List of tuples:
+                    (
+                        entity_iri (IRI),
+                        entity_type (str): 'class' | 'property' | 'individual'
+                    )
+
+            context:
+                Shared ontology/domain context used to ground generated comments.
+
+        Returns:
+            List[OWLAnnotationAssertionAxiom]:
+                One annotation assertion axiom per valid entity that received
+                a comment.
+        """
+        iri_type_pairs: list[tuple[str, Literal["class", "property", "individual"]]] = [(iri.as_str(), entity_type) for iri, entity_type in entities_meta]
+
+        valid_iri_set: set[str] = {iri.as_str() for iri, _ in entities_meta}
+
+        result = self.batch_rdfs_comment_generator(iri_type_pairs=iri_type_pairs, context=context)
+
+        axioms: list[OWLAnnotationAssertionAxiom] = []
+
+        for iri_str, comment in result.entity_comment_pairs:
+            if comment is None or iri_str not in valid_iri_set:
+                continue
+
+            entity_iri = IRI.create(iri_str)
+
+            axiom = self._get_annotation_assertion_axiom(entity_iri, RDFS_COMMENT_IRI, comment)
+
+            axioms.append(axiom)
+
+        return axioms

--- a/owlapy/agen_kg/helper.py
+++ b/owlapy/agen_kg/helper.py
@@ -1,3 +1,6 @@
+from itertools import islice
+from typing import Iterable, Iterator, TypeVar
+
 import dspy
 import requests
 
@@ -9,6 +12,9 @@ from owlapy.agen_kg.few_shot_examples import (
     EXAMPLES_FOR_TYPE_ASSERTION,
     EXAMPLES_FOR_TYPE_GENERATION,
 )
+
+RDFS_COMMENT_IRI = "http://www.w3.org/2000/01/rdf-schema#comment"
+RDFS_LABEL_IRI = "http://www.w3.org/2000/01/rdf-schema#label"
 
 # DBpedia often uses British English, so we define a mapping for common American to British English terms.
 american_to_british = {
@@ -31,22 +37,21 @@ american_to_british = {
     "program": "programme",  # when referring to TV/show
     "check": "cheque",  # bank sense
     "gray": "grey",
-    "plow": "plough"
+    "plow": "plough",
 }
 
 task_example_mapping = {
-    'entity_extraction': EXAMPLES_FOR_ENTITY_EXTRACTION,
-    'triples_extraction': EXAMPLES_FOR_TRIPLES_EXTRACTION,
-    'type_assertion': EXAMPLES_FOR_TYPE_ASSERTION,
-    'type_generation': EXAMPLES_FOR_TYPE_GENERATION,
-    'literal_extraction': EXAMPLES_FOR_LITERAL_EXTRACTION,
-    'triples_with_numeric_literals_extraction': EXAMPLES_FOR_SPL_TRIPLES_EXTRACTION
+    "entity_extraction": EXAMPLES_FOR_ENTITY_EXTRACTION,
+    "triples_extraction": EXAMPLES_FOR_TRIPLES_EXTRACTION,
+    "type_assertion": EXAMPLES_FOR_TYPE_ASSERTION,
+    "type_generation": EXAMPLES_FOR_TYPE_GENERATION,
+    "literal_extraction": EXAMPLES_FOR_LITERAL_EXTRACTION,
+    "triples_with_numeric_literals_extraction": EXAMPLES_FOR_SPL_TRIPLES_EXTRACTION,
 }
 
+
 def configure_dspy(signature):
-    lm = dspy.LM(model="openai/gpt-4o", api_key="<ENTER_API_KEY>",
-                 api_base=None,
-                 temperature=0.1, seed=42, cache=True)
+    lm = dspy.LM(model="openai/gpt-4o", api_key="<ENTER_API_KEY>", api_base=None, temperature=0.1, seed=42, cache=True)
     dspy.configure(lm=lm)
     model = dspy.Predict(signature)
     return model
@@ -54,15 +59,12 @@ def configure_dspy(signature):
 
 def run_query(query):
     """Runs a SPARQL query against the DBpedia SPARQL endpoint."""
-    params = {
-        "query": query,
-        "format": "application/sparql-results+json"
-    }
+    params = {"query": query, "format": "application/sparql-results+json"}
     response = requests.get("http://dbpedia.org/sparql", params=params)
     response.raise_for_status()
     data = response.json()
-    return [binding['superclass' if 'superclass' in binding else 'subclass']['value']
-            for binding in data['results']['bindings']]
+    return [binding["superclass" if "superclass" in binding else "subclass"]["value"] for binding in data["results"]["bindings"]]
+
 
 def extract_hierarchy_from_dbpedia(cls):
     """
@@ -86,3 +88,28 @@ def extract_hierarchy_from_dbpedia(cls):
     subclasses = run_query(subclass_query)
 
     return superclasses, subclasses
+
+
+T = TypeVar("T")
+
+
+def chunked_iterator(seq: Iterable[T], size: int = 20) -> Iterator[list[T]]:
+    """
+    Splits an iterable into fixed-size chunks and yields them sequentially.
+
+    This function consumes the input iterable lazily and groups its elements
+    into lists of a maximum given size. It is useful for batching data for
+    processing, such as API calls or LLM requests.
+
+    Args:
+        seq (Iterable[T]): The input iterable to be chunked.
+        size (int): The maximum number of elements per chunk. Defaults to 50.
+
+    Returns:
+        Iterator[list[T]]: An iterator over lists, where each list contains
+        up to `size` elements from the input iterable.
+    """
+    it = iter(seq)
+
+    while chunk := list(islice(it, size)):
+        yield chunk

--- a/owlapy/agen_kg/signatures.py
+++ b/owlapy/agen_kg/signatures.py
@@ -9,6 +9,7 @@ class Entity(dspy.Signature):
     task_instructions: str = dspy.InputField(desc="Specific instructions that must be considered.")
     entities: list[str] = dspy.OutputField(desc="List of key entities, capitalized.")
 
+
 class Triple(dspy.Signature):
     __doc__ = """Given a piece of text and entities, identify triples of type source_entity-relation-target_entity
     where source_entity and target_entity are strictly part of the given entities."""
@@ -16,7 +17,8 @@ class Triple(dspy.Signature):
     entities: list[str] = dspy.InputField(desc="List of entities to consider.")
     task_instructions: str = dspy.InputField(desc="Specific instructions that must be considered.")
     few_shot_examples: str = dspy.InputField(desc="Few shot examples for this task.")
-    triples: list[tuple[str,str,str]] = dspy.OutputField(desc="List of source_entity-relation-target_entity, capitalized.")
+    triples: list[tuple[str, str, str]] = dspy.OutputField(desc="List of source_entity-relation-target_entity, capitalized.")
+
 
 class TypeAssertion(dspy.Signature):
     __doc__ = """Given a list of entities, a list of types and textual contex, assign types to the entities."""
@@ -27,6 +29,7 @@ class TypeAssertion(dspy.Signature):
     task_instructions: str = dspy.InputField(desc="Specific instructions that must be considered.")
     pairs: list[tuple[str, str]] = dspy.OutputField(desc="List of entity-entity_type pairs.")
 
+
 class TypeGeneration(dspy.Signature):
     __doc__ = """Given a list of entities and textual contex, assign meaningful general types to the entities."""
     text: str = dspy.InputField(desc="A textual input about some topic.")
@@ -35,6 +38,7 @@ class TypeGeneration(dspy.Signature):
     task_instructions: str = dspy.InputField(desc="Specific instructions that must be considered.")
     pairs: list[tuple[str, str]] = dspy.OutputField(desc="List of entity-entity_type pairs.")
 
+
 class Literal(dspy.Signature):
     __doc__ = """Given a piece of text as input identify key numerical values extracted form the text. The result
     should be a list of numerical literals. E.g., ["123", "45.67", "50%", ...]"""
@@ -42,6 +46,7 @@ class Literal(dspy.Signature):
     task_instructions: str = dspy.InputField(desc="Specific instructions that must be considered.")
     few_shot_examples: str = dspy.InputField(desc="Few shot examples for this task.")
     l_values: list[str] = dspy.OutputField(desc="List of key numerical values.")
+
 
 class SPLTriples(dspy.Signature):
     __doc__ = """Given a piece of text, entities and numeric literals, identify triples of type
@@ -52,8 +57,8 @@ class SPLTriples(dspy.Signature):
     numeric_literals: list[str] = dspy.InputField(desc="List of literals to consider.")
     task_instructions: str = dspy.InputField(desc="Specific instructions that must be considered.")
     few_shot_examples: str = dspy.InputField(desc="Few shot examples for this task.")
-    triples: list[tuple[str, str, str]] = dspy.OutputField(
-        desc="List of source_entity-relation-target_value triples.")
+    triples: list[tuple[str, str, str]] = dspy.OutputField(desc="List of source_entity-relation-target_value triples.")
+
 
 class Domain(dspy.Signature):
     __doc__ = """Given a piece of text, identify the primary domain or topic of the text.
@@ -62,16 +67,19 @@ class Domain(dspy.Signature):
     text: str = dspy.InputField(desc="A textual input whose domain should be identified.")
     domain: str = dspy.OutputField(desc="Detected domain/category of the text, normalized (lowercase).")
 
+
 class DomainSpecificFewShotGenerator(dspy.Signature):
     __doc__ = """Given a domain (e.g., 'biology', 'finance', 'sports'), generate few-shot examples tailored to that domain
     for a specific task (entity extraction, triple extraction, type assertion, etc.). The examples should follow the same
     format as the general few-shot examples but with domain-specific content."""
     domain: str = dspy.InputField(desc="The domain for which to generate few-shot examples (e.g., 'biology', 'finance').")
-    task_type: str = dspy.InputField(desc="The task type: 'entity_extraction', 'triples_extraction', 'type_assertion', 'type_generation', 'literal_extraction', or 'triples_with_numeric_literals_extraction'.")
+    task_type: str = dspy.InputField(
+        desc="The task type: 'entity_extraction', 'triples_extraction', 'type_assertion', 'type_generation', 'literal_extraction', or 'triples_with_numeric_literals_extraction'."
+    )
     num_examples: int = dspy.InputField(desc="Number of examples to generate.", default=2)
-    examples_example_structure: str = dspy.InputField(
-        desc="The example structure to use as a guiding template for generating few-shot examples.")
+    examples_example_structure: str = dspy.InputField(desc="The example structure to use as a guiding template for generating few-shot examples.")
     few_shot_examples: str = dspy.OutputField(desc="Generated few-shot examples formatted as a string, following the standard format with Example 1, Example 2, etc.")
+
 
 class EntityDeduplication(dspy.Signature):
     __doc__ = """Given a list of entities, identify and remove redundant near-duplicates that refer to the same real-world entity.
@@ -82,6 +90,7 @@ class EntityDeduplication(dspy.Signature):
     text: str = dspy.InputField(desc="The original text context to help understand entity relationships.")
     filtered_entities: list[str] = dspy.OutputField(desc="Filtered list of entities with redundant near-duplicates removed.")
 
+
 class CoherenceChecker(dspy.Signature):
     __doc__ = """Given a batch of triples, textual context and optional instructions, evaluate the logical coherence and factual consistency
     of the triples. Rate each triple's coherence on a scale of 1-5, where 1 means incoherent, contradictory or trivial and 5 means highly
@@ -91,6 +100,7 @@ class CoherenceChecker(dspy.Signature):
     task_instructions: str = dspy.InputField(desc="Specific instructions that must be considered.")
     coherence_scores: list[tuple[tuple[str, str, str], int, str]] = dspy.OutputField(desc="List of tuples: (triple, coherence_score_1_to_5, explanation).")
 
+
 class TypeClustering(dspy.Signature):
     __doc__ = """Given a list of entity types, identify duplicates and near-duplicates that refer to the same conceptual type.
     Consider variations in spelling, singular/plural forms, synonyms, and different naming conventions. Return clusters of types
@@ -98,6 +108,7 @@ class TypeClustering(dspy.Signature):
     types: list[str] = dspy.InputField(desc="List of entity types to cluster and identify duplicates.")
     text: str = dspy.InputField(desc="The original text context to help understand type relationships.")
     clusters: list[tuple[list[str], str]] = dspy.OutputField(desc="List of tuples where each tuple contains (list_of_duplicate_types, canonical_type_name).")
+
 
 class RelationClustering(dspy.Signature):
     __doc__ = """Given a list of relations, identify duplicates and near-duplicates that refer to the same relationship.
@@ -115,12 +126,14 @@ class TextSummarizer(dspy.Signature):
     text: str = dspy.InputField(desc="A textual input to summarize.")
     summary: str = dspy.OutputField(desc="A concise summary preserving entities, relationships, types, and key facts.")
 
+
 class ChunkSummarizer(dspy.Signature):
     __doc__ = """Given multiple text chunk summaries, combine them into a unified comprehensive summary.
     The combined summary should deduplicate information, preserve all unique entities and relationships,
     and maintain coherence across the merged content."""
     chunk_summaries: list[str] = dspy.InputField(desc="List of summaries from different text chunks.")
     combined_summary: str = dspy.OutputField(desc="A unified summary that combines and deduplicates information from all chunks.")
+
 
 class EntityDeduplicationWithSummary(dspy.Signature):
     __doc__ = """Given a list of entities and a summary of the source text, identify and remove redundant near-duplicates
@@ -132,6 +145,7 @@ class EntityDeduplicationWithSummary(dspy.Signature):
     summary: str = dspy.InputField(desc="A summary of the original text context to help understand entity relationships.")
     filtered_entities: list[str] = dspy.OutputField(desc="Filtered list of entities with redundant near-duplicates removed.")
 
+
 class TypeClusteringWithSummary(dspy.Signature):
     __doc__ = """Given a list of entity types and a summary of the source text, identify duplicates and near-duplicates
     that refer to the same conceptual type. Consider variations in spelling, singular/plural forms, synonyms,
@@ -141,6 +155,7 @@ class TypeClusteringWithSummary(dspy.Signature):
     summary: str = dspy.InputField(desc="A summary of the original text context to help understand type relationships.")
     clusters: list[tuple[list[str], str]] = dspy.OutputField(desc="List of tuples where each tuple contains (list_of_duplicate_types, canonical_type_name).")
 
+
 class RelationClusteringWithSummary(dspy.Signature):
     __doc__ = """Given a list of relations and a summary of the source text, identify duplicates and near-duplicates
     that refer to the same relationship. Consider variations in spelling, synonyms, different phrasings,
@@ -149,6 +164,7 @@ class RelationClusteringWithSummary(dspy.Signature):
     relations: list[str] = dspy.InputField(desc="List of relations to cluster and identify duplicates.")
     summary: str = dspy.InputField(desc="A summary of the original text context to help understand relation meanings.")
     clusters: list[tuple[list[str], str]] = dspy.OutputField(desc="List of tuples where each tuple contains (list_of_duplicate_relations, canonical_relation_name).")
+
 
 class IncrementalEntityMerger(dspy.Signature):
     __doc__ = """Given two sets of entities from different text chunks along with context, merge them into a unified
@@ -161,6 +177,7 @@ class IncrementalEntityMerger(dspy.Signature):
     merged_entities: list[str] = dspy.OutputField(desc="Unified list of entities with duplicates merged to canonical forms.")
     entity_mapping: list[tuple[str, str]] = dspy.OutputField(desc="List of (original_entity, canonical_entity) mappings for entities that were merged.")
 
+
 class IncrementalTripleMerger(dspy.Signature):
     __doc__ = """Given two sets of triples from different text chunks along with context, merge them into a unified
     list. Identify triples that represent the same relationship (possibly with different wording) and produce
@@ -171,6 +188,7 @@ class IncrementalTripleMerger(dspy.Signature):
     context_b: str = dspy.InputField(desc="Summary/context from chunk B.")
     merged_triples: list[tuple[str, str, str]] = dspy.OutputField(desc="Unified list of triples with semantic duplicates merged.")
 
+
 class IncrementalTypeMerger(dspy.Signature):
     __doc__ = """Given two sets of entity-type pairs from different text chunks, merge them into a unified list.
     Resolve any conflicting type assignments for the same entity, preferring more specific types.
@@ -180,6 +198,7 @@ class IncrementalTypeMerger(dspy.Signature):
     context_a: str = dspy.InputField(desc="Summary/context from chunk A.")
     context_b: str = dspy.InputField(desc="Summary/context from chunk B.")
     merged_types: list[tuple[str, str]] = dspy.OutputField(desc="Unified list of entity-type pairs with conflicts resolved.")
+
 
 class PlanDecomposer(dspy.Signature):
     __doc__ = """We want to extract knowledge from text in triples format. The pipeline follows these steps:
@@ -194,3 +213,49 @@ class PlanDecomposer(dspy.Signature):
     literal_extraction_task: str = dspy.OutputField(desc="Sub-task description for literal extraction.")
     triple_with_literal_extraction_task: str = dspy.OutputField(desc="Sub-task description for triple extraction with numeric literals.")
     fact_checking_task: str = dspy.OutputField(desc="Sub-task description for fact checking and coherence verification of extracted triples.")
+
+
+class BatchRdfsCommentGenerator(dspy.Signature):
+    __doc__ = """We want to generate rdfs:comment annotations for OWL ontology entities.
+
+    ENTITY SEMANTICS:
+    - class: TBox concept (universal category).
+    - property: TBox relation (no concrete values allowed).
+    - individual: ABox instance (named individual in the ontology).
+
+    CRITICAL RULES:
+    - NEVER invent facts not present in the context or IRI.
+    - For classes and properties: describe ONLY general meaning (TBox level).
+    - For individuals: describe their role according to the context's content.
+    - If no grounded description exists, return null.
+    - For each comment, internally identify which phrases from the context support it; do not include unsupported concepts.
+    - Keep comments concise and ontology-style, not narrative."""
+    context: str = dspy.InputField(desc="Shared ontology/domain context used to ground generated comments.")
+    iri_type_pairs: list[tuple[str, str]] = dspy.InputField(
+        desc="""List of entities to annotate.
+
+        Each tuple has:
+        - index 0: entity IRI string
+        - index 1: entity type string ('class', 'property', or 'individual')
+
+        Example:
+        [
+            ('http://example.org/Person', 'class'),
+            ('http://example.org/hasName', 'property'),
+            ('http://example.org/john_doe', 'individual')
+        ]"""
+    )
+    entity_comment_pairs: list[tuple[str, str | None]] = dspy.OutputField(
+        desc="""List of generated annotations.
+
+        Each tuple has:
+        - index 0: entity IRI string
+        - index 1: generated rdfs:comment string, or null if insufficient context exists
+
+        Example:
+        [
+            ('http://example.org/Person', 'Represents a human individual.'),
+            ('http://example.org/hasName', 'Relates an entity to its name.'),
+            ('http://example.org/john_doe', 'A person that...')
+        ]"""
+    )

--- a/tests/test_owlapy_graph_extractor.py
+++ b/tests/test_owlapy_graph_extractor.py
@@ -1,0 +1,144 @@
+import unittest
+
+from owlapy.agen_kg.graph_extracting_models.domain_graph_extractor import DomainGraphExtractor
+from owlapy.agen_kg.helper import RDFS_LABEL_IRI, chunked_iterator
+from owlapy.iri import IRI
+from owlapy.owl_axiom import (
+    OWLAnnotation,
+    OWLAnnotationAssertionAxiom,
+    OWLAnnotationProperty,
+    OWLLiteral,
+)
+
+
+class TestGraphExtractor(unittest.TestCase):
+    """Test annotation assertion axiom generation provided by the abstract GraphExtractor class"""
+
+    def setUp(self):
+        """Create test instance"""
+        self.graph_extractor = DomainGraphExtractor()
+        self.test_class_iri_str = "http://example.org/TestClass"
+        self.test_annotation_iri_str = "http://example.org/testAnnotation"
+
+    def test_get_annotation_assertion_axiom(self):
+        """Test creation of generic annotation assertion axiom"""
+
+        entity_iri = IRI.create(self.test_class_iri_str)
+        annotation_iri = IRI.create(self.test_annotation_iri_str)
+        value = "Test annotation"
+
+        result = self.graph_extractor._get_annotation_assertion_axiom(entity_iri=entity_iri, annotation_iri=annotation_iri, value=value)
+
+        expected = OWLAnnotationAssertionAxiom(entity_iri, OWLAnnotation(OWLAnnotationProperty(annotation_iri), OWLLiteral(value)))
+
+        self.assertEqual(result, expected)
+
+    def test_get_rdfs_label_axiom(self):
+        """Test creation of rdfs:label annotation assertion axiom"""
+
+        entity_iri = IRI.create(self.test_class_iri_str)
+        label = "Test class"
+
+        result = self.graph_extractor.get_rdfs_label_axiom(entity_iri=entity_iri, label=label)
+
+        expected_annotation_iri = IRI.create(RDFS_LABEL_IRI)
+
+        expected = OWLAnnotationAssertionAxiom(entity_iri, OWLAnnotation(OWLAnnotationProperty(expected_annotation_iri), OWLLiteral(label)))
+
+        self.assertEqual(result, expected)
+
+    def test_format_rdfs_label_uppercase_class_name(self):
+        """Test formatting uppercase class label"""
+        result = DomainGraphExtractor.format_rdfs_label("PERSON")
+        self.assertEqual(result, "Person")
+
+    def test_format_rdfs_label_snake_case_class_name(self):
+        """Test formatting snake_case class label"""
+        result = DomainGraphExtractor.format_rdfs_label("person_type")
+        self.assertEqual(result, "Person type")
+
+    def test_format_rdfs_label_space_separated_class_name(self):
+        """Test formatting space separated class label"""
+        result = DomainGraphExtractor.format_rdfs_label("PERSON TYPE")
+        self.assertEqual(result, "Person type")
+
+    def test_format_rdfs_label_property_name(self):
+        """Test formatting property label"""
+        result = DomainGraphExtractor.format_rdfs_label("has_name", is_property=True)
+        self.assertEqual(result, "has name")
+
+    def test_format_rdfs_label_property_uppercase(self):
+        """Test formatting uppercase property label"""
+        result = DomainGraphExtractor.format_rdfs_label("HAS_PARENT", is_property=True)
+        self.assertEqual(result, "has parent")
+
+    def test_format_rdfs_label_single_word_class(self):
+        """Test formatting single word class label"""
+        result = DomainGraphExtractor.format_rdfs_label("Vehicle")
+        self.assertEqual(result, "Vehicle")
+
+    def test_format_rdfs_label_single_word_property(self):
+        """Test formatting single word property label"""
+        result = DomainGraphExtractor.format_rdfs_label("CREATEDBY", is_property=True)
+        self.assertEqual(result, "createdby")
+
+    def test_format_rdfs_label_multiple_underscores(self):
+        """Test formatting label with multiple underscores"""
+        result = DomainGraphExtractor.format_rdfs_label("very_long_entity_name")
+        self.assertEqual(result, "Very long entity name")
+
+    def test_format_rdfs_label_empty_string(self):
+        """Test formatting empty label"""
+        result = DomainGraphExtractor.format_rdfs_label("")
+        self.assertEqual(result, "")
+
+
+class TestGraphExtractorHelpers(unittest.TestCase):
+    """Test GraphExtractor helpers"""
+
+    def test_chunked_iterator_exact_division(self):
+        """Test chunking when sequence divides exactly into equal parts"""
+        data = [1, 2, 3, 4]
+        result = list(chunked_iterator(data, size=2))
+        self.assertEqual(result, [[1, 2], [3, 4]])
+
+    def test_chunked_iterator_non_exact_division(self):
+        """Test chunking when sequence does not divide evenly"""
+        data = [1, 2, 3, 4, 5]
+        result = list(chunked_iterator(data, size=2))
+        self.assertEqual(result, [[1, 2], [3, 4], [5]])
+
+    def test_chunked_iterator_size_larger_than_input(self):
+        """Test chunking when chunk size exceeds input length"""
+        data = [1, 2, 3]
+        result = list(chunked_iterator(data, size=10))
+        self.assertEqual(result, [[1, 2, 3]])
+
+    def test_chunked_iterator_single_element_chunks(self):
+        """Test chunking when size is 1"""
+        data = [1, 2, 3]
+        result = list(chunked_iterator(data, size=1))
+        self.assertEqual(result, [[1], [2], [3]])
+
+    def test_chunked_iterator_empty_input(self):
+        """Test chunking with an empty iterable"""
+        data = []
+        result = list(chunked_iterator(data, size=3))
+        self.assertEqual(result, [])
+
+    def test_chunked_iterator_works_with_iterable_not_list(self):
+        """Test chunking with a generator input"""
+        data = (x for x in range(5))
+        result = list(chunked_iterator(data, size=2))
+        self.assertEqual(result, [[0, 1], [2, 3], [4]])
+
+    def test_chunked_iterator_does_not_eagerly_consume(self):
+        """Test that iterator is consumed lazily"""
+        data = iter([1, 2, 3, 4, 5])
+        it = chunked_iterator(data, size=2)
+
+        first = next(it)
+        self.assertEqual(first, [1, 2])
+
+        second = next(it)
+        self.assertEqual(second, [3, 4])


### PR DESCRIPTION
## Additions

The `GraphExtractor` subclasses in the `agen_kg` module now support the creation of `rdfs:label` and `rdfs:comment` annotations for ontology entities.

These annotations are added as the final step of the pipeline, immediately before the ontology is saved to disk.

Users can enable annotation generation by setting the boolean flag `generate_rdfs_annotations=True` in the `generate_ontology` method (default: `False`).

### rdfs:label

The `rdfs:label` annotation is computed deterministically from the entity's IRI by removing underscores (when present) and capitalizing the resulting text. I chose not to use an LLM for this task in order to reduce token usage, as LLMs would be excessive for this type of transformation. The quality of the generated `rdfs:label` therefore depends on the quality of the underlying IRI: poorly formatted IRIs will naturally produce poorly formatted labels. Improving IRI formatting may be worth exploring in the future.

### rdfs:comment

`rdfs:comment` annotations are generated through LLM calls. Entities are grouped into small fixed-size batches, and one LLM call is performed per batch. The LLM also expects a `context` argument from which comments can be generated. For this purpose, I reused the `clustering_context` produced in earlier stages of the pipeline, as it already provides suitable contextual information.

Grouping entities into batches has two main advantages:

1. Reduced token usage (a per-entity approach would require sending the `context` for every individual entity).
2. Improved performance (generating annotations for batches of entities is significantly faster than issuing one API call per entity).

## Notes

1. This Pull Request also contains changes to lines unrelated to the new feature. These modifications were automatically applied by `ruff` during pre-commit checks to address pre-existing formatting issues. I chose to keep these changes to remain compliant with the `CONTRIBUTING.md` guidelines.
2. As requested in the `CONTRIBUTING.md` file, I added tests for (deterministic) functions introduced in the codebase.