### PR TITLE
docs: add CLAUDE.md and path-scoped Claude Code rules

### DIFF
--- a/.claude/rules/class-expressions.md
+++ b/.claude/rules/class-expressions.md
@@ -1,0 +1,52 @@
+---
+paths:
+  - "owlapy/class_expression/**/*.py"
+  - "owlapy/utils.py"
+  - "tests/test_ce_simplifier.py"
+  - "tests/test_class_expression_semantics.py"
+  - "tests/test_owlapy_nnf.py"
+  - "tests/test_OWLObjectComplementOf.py"
+  - "tests/test_data_cardinality_restrictions.py"
+---
+
+# OWL Class Expressions
+
+All class expressions inherit from `OWLClassExpression` (`owlapy.class_expression`).
+
+```python
+from owlapy.class_expression import (
+    OWLClass, OWLThing, OWLNothing,
+    OWLObjectIntersectionOf, OWLObjectUnionOf, OWLObjectComplementOf,
+    OWLObjectSomeValuesFrom, OWLObjectAllValuesFrom,
+    OWLObjectMinCardinality, OWLObjectMaxCardinality, OWLObjectExactCardinality,
+    OWLObjectHasValue, OWLObjectHasSelf, OWLObjectOneOf,
+    OWLDataSomeValuesFrom, OWLDataAllValuesFrom,
+    OWLDataMinCardinality, OWLDataMaxCardinality, OWLDataExactCardinality,
+    OWLDataHasValue, OWLDataOneOf, OWLDatatypeRestriction, OWLFacetRestriction,
+)
+from owlapy.owl_property import OWLObjectProperty, OWLDataProperty, OWLObjectInverseOf
+```
+
+## Constraints
+
+- `OWLObjectIntersectionOf` / `OWLObjectUnionOf` take a **list** of operands, not varargs
+- `OWLObjectMinCardinality(n, property, filler)` — cardinality is the first argument
+- Data restrictions use `OWLDataProperty`; object restrictions use `OWLObjectProperty` — don't mix up `OWLDataSomeValuesFrom` vs `OWLObjectSomeValuesFrom`
+- `OWLObjectOneOf` takes a list of `OWLNamedIndividual` (nominals)
+- Facets: `OWLFacet.MIN_INCLUSIVE` / `MAX_INCLUSIVE` / `MIN_EXCLUSIVE` / `MAX_EXCLUSIVE` (`owlapy.vocab`)
+- Inverse object property: `OWLObjectInverseOf(prop)`
+
+## Simplification and Normal Forms
+
+```python
+from owlapy.utils import simplify_class_expression, get_expression_length, CESimplifier, NNF
+
+simplified = simplify_class_expression(ce)
+length = get_expression_length(ce)          # structural complexity
+nnf_ce = ce.get_nnf()                        # or NNF().get_class_nnf(ce)
+neg_ce = ce.get_object_complement_of()
+```
+
+Only NNF is implemented — there is no CNF/DNF transformer; don't invent one without checking `owlapy/utils.py` first.
+
+Utility methods available on any expression: `ce.is_owl_thing()`, `ce.is_owl_nothing()`, `ce.get_nnf()`, `ce.get_object_complement_of()`.

--- a/.claude/rules/kg-generation.md
+++ b/.claude/rules/kg-generation.md
@@ -1,0 +1,50 @@
+---
+paths:
+  - "owlapy/agen_kg/**/*.py"
+  - "examples/ag-gen_example.py"
+---
+
+# AGen-KG: LLM-Based Knowledge Graph Generation
+
+Requires `dspy` (`pip install owlapy[agentic]`). Pipeline: load text -> extract
+entities/relations/types via LLM -> cluster/dedupe relations -> generate class
+hierarchy + individuals -> save `.owl`.
+
+```python
+from owlapy.agen_kg import AGenKG
+
+agent = AGenKG(
+    model="gpt-4o", api_key="<KEY>", api_base="https://models.github.ai/inference",
+    temperature=0.1,     # 0.0-0.2 for factual extraction
+    seed=42,              # reproducibility
+    max_tokens=6000,      # default 4000; raise for large/complex docs
+    enable_logging=True,  # strongly recommended
+    cache=True,           # avoid redundant LLM calls during iteration
+)
+agent.generate_ontology(text="path/or/string", ontology_type="domain", save_path="out.owl")
+```
+
+`ontology_type`: `"domain"` (auto-detects domain, generates domain-specific few-shot
+examples — best for structured docs) vs `"open"` (no domain assumption, generic prompts).
+
+## Chunking Large Documents
+
+```python
+agent.configure_chunking(chunk_size=3000, overlap=200, strategy="sentence",
+                          auto_chunk_threshold=4000, summarization_threshold=8000,
+                          max_summary_length=3000)
+```
+
+## Internals
+
+`owlapy.agen_kg.graph_extracting_models` has `DomainGraphExtractor` (caches few-shot
+examples in `path_hidden/domain_examples_<domain>.json`) and `OpenGraphExtractor`.
+`owlapy.agen_kg.chunking_models` implements the chunking strategies.
+
+## Constraints
+
+- `save_path` must end in `.owl` (RDF/XML)
+- Very short texts (<50 words) yield poor extraction quality
+- `temperature=0.1, seed=42` is the recommended reproducible default
+- Any OpenAI-compatible endpoint works (OpenAI, Azure OpenAI, GitHub Models, Ollama, vLLM) — just swap `api_base`/`model`
+- Wrap `generate_ontology` calls in try/except for `FileNotFoundError`, `UnicodeDecodeError`, `ConnectionError`; validate the output ontology isn't empty before trusting it

--- a/.claude/rules/ontology-management.md
+++ b/.claude/rules/ontology-management.md
@@ -1,0 +1,62 @@
+---
+paths:
+  - "owlapy/owl_ontology.py"
+  - "owlapy/util_owl_static_funcs.py"
+  - "owlapy/owl_axiom.py"
+  - "tests/test_ontology.py"
+  - "tests/test_sync_ontology*.py"
+  - "tests/test_owlapy_ontology_management.py"
+  - "tests/test_owl_static_funcs.py"
+  - "tests/test_owl_hierarchy.py"
+---
+
+# Ontology Management
+
+```python
+from owlapy.owl_ontology import SyncOntology, Ontology, NeuralOntology
+from owlapy.util_owl_static_funcs import create_ontology, csv_to_rdf_kg, save_owl_class_expressions
+
+onto = SyncOntology("path/to/ontology.owl")            # preferred: thread-safe owlready2 wrapper
+onto = Ontology("path/to/ontology.owl")                  # lower-level owlready2-backed
+onto = create_ontology("file:/my_ontology.owl", with_owlapi=False)
+```
+
+## Signature and Axioms
+
+```python
+onto.classes_in_signature() / individuals_in_signature() / object_properties_in_signature() / data_properties_in_signature()
+onto.get_tbox_axioms()   # schema/class-level
+onto.get_abox_axioms()   # assertions/individual-level
+onto.equivalent_classes_axioms(cls); onto.general_class_axioms()
+onto.data_property_domain_axioms(prop); onto.data_property_range_axioms(prop)
+onto.object_property_domain_axioms(prop); onto.object_property_range_axioms(prop)
+```
+
+Add/remove axioms with `onto.add_axiom([...])` / `onto.remove_axiom(axiom)`. Common axiom types
+(`owlapy.owl_axiom`): `OWLDeclarationAxiom`, `OWLClassAssertionAxiom(ind, cls)`,
+`OWLObjectPropertyAssertionAxiom(subj, prop, obj)`, `OWLDataPropertyAssertionAxiom(subj, prop, literal)`,
+`OWLSubClassOfAxiom(sub, super)`, `OWLEquivalentClassesAxiom([...])`, `OWLDisjointClassesAxiom([...])`,
+`OWLObjectPropertyDomainAxiom`/`RangeAxiom`, `OWLSubPropertyAxiom`.
+
+## Saving
+
+```python
+onto.save(inplace=True)
+onto.save(path="output.owl", inplace=False)
+onto.save(path="output.ttl", rdf_format="ttl", inplace=False)
+```
+
+## CSV -> RDF and Saving Class Expressions
+
+```python
+csv_to_rdf_kg(path_csv="data.csv", path_kg="kg.owl", namespace="http://myproject.com/kg")
+save_owl_class_expressions(expressions=[expr1, expr2], path="predictions.owl",
+                            rdf_format="rdfxml", namespace="https://dice-research.org/predictions#")
+```
+
+## Constraints
+
+- Use full IRIs or `IRI.create(namespace, remainder)` when constructing entities — never bare strings
+- `SyncOntology` is preferred for most use cases; `Ontology` is the lower-level class
+- `create_ontology` paths need a valid file URI scheme (e.g. `"file:/path.owl"`)
+- Don't pass `with_owlapi=True` unless Java/OWLAPI interop is explicitly needed — it starts a JVM (see `.claude/rules/owlapi-swrl.md`)

--- a/.claude/rules/owlapi-swrl.md
+++ b/.claude/rules/owlapi-swrl.md
@@ -1,0 +1,60 @@
+---
+paths:
+  - "owlapy/swrl.py"
+  - "owlapy/owlapi_mapper.py"
+  - "owlapy/owlapi_dlsyntax.py"
+  - "owlapy/static_funcs.py"
+  - "tests/test_swrl.py"
+  - "tests/test_owlapi_dlsyntax.py"
+  - "tests/test_owlapi_mapper.py"
+---
+
+# OWLAPI Bridge and SWRL Rules
+
+## JVM Lifecycle
+
+```python
+from owlapy.static_funcs import startJVM, stopJVM
+startJVM()   # usually automatic (SyncReasoner, Ontology(with_owlapi=True))
+stopJVM()    # ALWAYS call when done — every path, including exceptions
+```
+
+```python
+from owlapy.owlapi_mapper import OWLAPIMapper   # owlapy <-> OWLAPI Java object mapping
+from owlapy.owlapi_dlsyntax import OWLAPIRenderer  # DL rendering via OWLAPI's own renderer
+onto = SyncOntology("KGs/Family/father.owl", with_owlapi=True)  # starts JVM
+```
+
+## SWRL
+
+```python
+from owlapy.swrl import Rule, Atom, ClassAtom, ObjectPropertyAtom, DataPropertyAtom, BuiltInAtom, IVariable, DVariable
+from owlapy.iri import IRI
+
+x = IVariable(IRI.create("urn:swrl:var#", "x"))   # individual/object variable
+v = DVariable(IRI.create("urn:swrl:var#", "v"))   # data/literal variable
+
+person_atom = ClassAtom(OWLClass(NS + "Person"), x)
+has_child_atom = ObjectPropertyAtom(OWLObjectProperty(NS + "hasChild"), x, y)
+age_atom = DataPropertyAtom(OWLDataProperty(NS + "age"), x, v)
+builtin_atom = BuiltInAtom(IRI.create("http://www.w3.org/2003/11/swrlb#", "greaterThan"), [v, OWLLiteral(18)])
+
+# Person(?x) ∧ hasChild(?x,?y) ∧ Male(?y) -> Father(?x)
+rule = Rule(body_atoms=[person_atom, has_child_atom, male_atom], head_atoms=[father_atom])
+onto.add_axiom(rule)   # SWRL rules are added like any other axiom
+onto.save(inplace=True)
+```
+
+Common built-ins (base `http://www.w3.org/2003/11/swrlb#`): `greaterThan`, `lessThan`,
+`greaterThanOrEqual`, `lessThanOrEqual`, `equal`, `add`, `subtract`, `multiply`, `divide`,
+`stringConcat`, `matches`.
+
+Retrieving rules: they appear as axioms in `onto.get_tbox_axioms()`; check `isinstance(axiom, Rule)`.
+`axiom.body` / `axiom.head` are properties, not methods.
+
+## Constraints
+
+- OWLAPI bridge always requires a JVM — call `stopJVM()` when done
+- Variable IRIs must be unique within a rule; convention is `urn:swrl:var#<name>`
+- `IVariable` for individuals/objects, `DVariable` for literals
+- SWRL rules are only honored by complete reasoners (HermiT, Pellet), never `StructuralReasoner`

--- a/.claude/rules/reasoning.md
+++ b/.claude/rules/reasoning.md
@@ -1,0 +1,81 @@
+---
+paths:
+  - "owlapy/owl_reasoner.py"
+  - "owlapy/owl_reasoner_rdflib.py"
+  - "owlapy/static_funcs.py"
+  - "tests/test_owlapy_structural_reasoner.py"
+  - "tests/test_sync_reasoner.py"
+  - "tests/test_rdflib_reasoner*.py"
+  - "tests/test_reasoner_*.py"
+  - "tests/test_ontology_justification.py"
+---
+
+# OWL Reasoning
+
+| Reasoner | Class | Backend | Notes |
+|---|---|---|---|
+| `StructuralReasoner` | `owlapy.owl_reasoner.StructuralReasoner` | owlready2 (pure Python) | Fast, incomplete, no JVM |
+| `RDFLibReasoner` | `owlapy.owl_reasoner_rdflib.RDFLibReasoner` | rdflib (pure Python) | No JVM |
+| `SyncReasoner("HermiT"\|"Pellet"\|"JFact"\|"Openllet"\|"Structural")` | `owlapy.owl_reasoner.SyncReasoner` | Java/OWLAPI | Complete DL reasoning |
+| `SyncReasoner("ELK")` | same | Java/OWLAPI | EL fragment only, very fast, no universals/nominals/inverses |
+
+## StructuralReasoner (no JVM)
+
+```python
+from owlapy.owl_reasoner import StructuralReasoner
+from owlapy.owl_ontology import Ontology
+from owlapy.class_expression import OWLClass
+
+reasoner = StructuralReasoner(Ontology("KGs/Family/father.owl"))  # or pass a path directly
+instances = set(reasoner.instances(OWLClass("http://example.com/father#male")))  # generator -> materialize
+sub_classes = set(reasoner.sub_classes(cls, direct=True))
+super_classes = set(reasoner.super_classes(cls, direct=False))
+equiv = set(reasoner.equivalent_classes(cls))
+disjoint = set(reasoner.disjoint_classes(cls))
+children = set(reasoner.object_property_values(individual, prop))
+values = set(reasoner.data_property_values(individual, data_prop))
+```
+
+## SyncReasoner (Java, requires JVM)
+
+```python
+from owlapy.owl_reasoner import SyncReasoner
+from owlapy.static_funcs import stopJVM
+
+sync_reasoner = SyncReasoner(ontology="KGs/Family/family-benchmark_rich_background.owl", reasoner="Pellet")
+instances = sync_reasoner.instances(ce)
+subs = sync_reasoner.sub_classes(cls, direct=False)
+stopJVM()   # ALWAYS — every code path, including exceptions
+```
+
+## Ontology Enrichment
+
+```python
+sync_reasoner.infer_axioms_and_save(
+    output_path="enriched.ttl", output_format="ttl",
+    inference_types=["InferredClassAssertionAxiomGenerator", "InferredSubClassAxiomGenerator"],  # omit for all
+)
+stopJVM()
+```
+
+## Justifications
+
+```python
+from owlapy import manchester_to_owl_expression
+target = manchester_to_owl_expression("hasChild some Female", namespace)
+justifications = reasoner.create_justifications({individual}, target, save=True)
+stopJVM()
+```
+
+## CLI
+
+```bash
+owlapy --path_ontology "KGs/Family/family-benchmark_rich_background.owl" --inference_types "all" --out_ontology "enriched_family.owl"
+```
+
+## Constraints
+
+- **Always call `stopJVM()`** after any Java-backed reasoner (`SyncReasoner`); `StructuralReasoner` and `RDFLibReasoner` never need it
+- `instances()` returns a generator — wrap in `set()`/`list()`
+- ELK only supports the EL fragment
+- Prefer `StructuralReasoner` for speed on large ontologies when incompleteness is acceptable; use `SyncReasoner` with HermiT/Pellet for DL-complete results and SWRL

--- a/.claude/rules/syntax-conversion.md
+++ b/.claude/rules/syntax-conversion.md
@@ -1,0 +1,55 @@
+---
+paths:
+  - "owlapy/parser.py"
+  - "owlapy/render.py"
+  - "owlapy/converter.py"
+  - "owlapy/__init__.py"
+  - "tests/test_owlapy_conversions.py"
+  - "tests/test_converter_extended.py"
+  - "tests/test_owlapy_owl2sparql_converter.py"
+---
+
+# Syntax Conversion (DL / Manchester / SPARQL)
+
+## Rendering (OWL object -> string)
+
+```python
+from owlapy import owl_expression_to_dl, owl_expression_to_manchester, owl_expression_to_sparql
+from owlapy import owl_expression_to_sparql_with_confusion_matrix  # adds pos/neg vars for ML eval
+
+owl_expression_to_dl(ce)          # "(∃ hasChild.male) ⊓ teacher"
+owl_expression_to_manchester(ce)  # "hasChild some male and teacher"
+owl_expression_to_sparql(ce)      # SELECT DISTINCT ?x WHERE { ... }
+```
+
+## Parsing (string -> OWL object)
+
+```python
+from owlapy import dl_to_owl_expression, manchester_to_owl_expression
+
+ce = dl_to_owl_expression("∃ hasChild.Male", "http://example.com/family#")
+ce = manchester_to_owl_expression("hasChild some Female", "http://www.benchmark.org/family#")
+```
+
+`namespace` is a base prefix string ending in `#` or `/`; parsers append the class/property name to it to build full IRIs.
+
+## Symbol Reference
+
+| Symbol | Meaning | Class |
+|---|---|---|
+| `⊓` | AND | `OWLObjectIntersectionOf` |
+| `⊔` | OR | `OWLObjectUnionOf` |
+| `¬` | NOT | `OWLObjectComplementOf` |
+| `∃` | some | `OWLObjectSomeValuesFrom` |
+| `∀` | only | `OWLObjectAllValuesFrom` |
+| `≥ n` / `≤ n` / `= n` | cardinality | `OWLObjectMinCardinality` / `Max` / `Exact` |
+| `⊤` / `⊥` | Thing / Nothing | `OWLThing` / `OWLNothing` |
+| `⊑` / `≡` | subclass / equivalent | `OWLSubClassOfAxiom` / `OWLEquivalentClassesAxiom` |
+| `⁻` | inverse | `OWLObjectInverseOf` |
+| `{a}` | nominal | `OWLObjectOneOf` |
+
+## Constraints
+
+- SPARQL output uses `SELECT DISTINCT ?x` where `?x` represents instances
+- When verifying a conversion, round-trip it (parse -> render, or build -> render -> parse) rather than eyeballing the string
+- Same functions are importable from `owlapy` directly or from their defining submodule (`owlapy.parser`, `owlapy.render`, `owlapy.converter`) — prefer the top-level `owlapy` import in new code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# owlapy
+
+Pure-Python framework for OWL 2 ontology engineering, semantic reasoning, and
+LLM-based knowledge graph generation. Developed by the DICE Research Group,
+Paderborn University. Current version: see `owlapy/__init__.py`.
+
+Deep API documentation already exists in `markdown_docs/` (core concepts,
+ontology management, reasoning, common patterns, API reference) — read the
+relevant file there before explaining owlapy APIs at length.
+
+## Environment
+
+Always use the `temp_owlapy` conda environment:
+
+```bash
+conda create -n temp_owlapy python=3.11 --no-default-packages
+conda activate temp_owlapy
+pip install -e '.[dev]'
+```
+
+Python 3.11 is required (matches CI and the README install command, not 3.10.x).
+
+## Lint, Test, Build
+
+```bash
+# Lint (always run before committing)
+ruff check owlapy --line-length=200
+ruff check owlapy --line-length=200 --fix --unsafe-fixes
+
+# Tests (download KGs.zip once, see below)
+PYTHONPATH=. pytest --ignore=tests/test_z_do_last_ebr_retrieval.py -p no:warnings
+
+# Coverage
+coverage run -m pytest --ignore=tests/test_z_do_last_ebr_retrieval.py -p no:warnings -x
+coverage report -m
+```
+
+- Test KGs (one-time): `wget https://files.dice-research.org/projects/Ontolearn/KGs.zip -O ./KGs.zip && unzip KGs.zip`
+- `tests/test_z_do_last_ebr_retrieval.py` is slow and excluded from the default run by convention (runs last, retrains embeddings)
+- Test files: `tests/test_*.py`, functions `test_*` (pytest, `pythonpath = ["."]`, configured in `pyproject.toml`)
+- mypy config lives in `pyproject.toml` (`check_untyped_defs = true`, `disallow_untyped_defs = false` — gradual typing, tighten over time, don't relax)
+
+## Project Structure
+
+```
+owlapy/
+├── class_expression/     # OWL class expression types (see .claude/rules/class-expressions.md)
+├── entities/, abstracts/ # Entity base types and abstract interfaces
+├── agen_kg/               # LLM-based ontology generation, AGenKG (see .claude/rules/kg-generation.md)
+├── scripts/               # CLI entry points: `owlapy`, `owlapy-serve`
+├── jar_dependencies/      # Bundled Java .jars for HermiT, Pellet, ELK, JFact, Openllet
+├── owl_ontology.py         # SyncOntology, Ontology, NeuralOntology
+├── owl_reasoner.py         # StructuralReasoner, SyncReasoner
+├── owl_reasoner_rdflib.py  # RDFLibReasoner (pure Python)
+├── owl_axiom.py             # All OWL axiom types
+├── converter.py             # OWL -> SPARQL
+├── parser.py                 # DL / Manchester -> OWL
+├── render.py                  # OWL -> DL / Manchester
+├── swrl.py                     # SWRL rules
+├── owlapi_mapper.py, owlapi_dlsyntax.py  # Java OWLAPI bridge
+└── utils.py                     # CESimplifier, NNF, similarity metrics
+tests/                    # pytest suite, one file per module/feature
+examples/                 # Runnable usage scripts (mirrors markdown_docs topics)
+markdown_docs/            # LLM-friendly deep-dive docs — check here first for API detail
+KGs/                       # Test ontologies (downloaded, not committed)
+.github/agents/            # Legacy GitHub Copilot agent specs — superseded by .claude/rules/
+```
+
+## Key Design Principles
+
+- Prefer `SyncOntology` over `Ontology` for new code (thread-safe wrapper)
+- Never pass raw strings to reasoners — wrap in the appropriate OWL object first; use full IRI strings when constructing entities
+- Always call `stopJVM()` (from `owlapy.static_funcs`) after using any Java-backed reasoner (`SyncReasoner`, OWLAPI bridge). `StructuralReasoner` is pure Python and needs no JVM.
+- Never guess owlapy import paths — verify against the actual module (see `.claude/rules/` for the domain you're touching)
+
+## Versioning
+
+Version is tracked in **two places** and must stay in sync:
+- `owlapy/__init__.py` → `__version__`
+- `setup.py` → `version=`
+
+## Dependency Notes
+
+- `dicee` pinned `>=0.3.2,<0.4.0`; `dspy` pinned `>=3.0.3,<4.0.0` (verified against 3.1.3) — do not switch to strict `==` pinning
+- Java reasoners require JPype1 + bundled jars in `owlapy/jar_dependencies/`
+- `agen_kg` requires `dspy` — install via `pip install owlapy[agentic]`
+
+## Git Workflow
+
+Gitflow: `main` (releases) ← `develop` (integration) ← `feature/*` / `fix/*` / `chore/*`
+branches. Open PRs against `develop`, not `main`. Release process (version bump in
+both files, CHANGELOG.md update, merge develop → main, tag, build, `twine upload`)
+is documented in `.github/copilot-instructions.md` if you're driving a release.
+
+## Rules
+
+Domain-specific API patterns and constraints load automatically from
+`.claude/rules/` when you touch matching files (class expressions, ontology
+management, reasoning, syntax conversion, SWRL/OWLAPI, KG generation).


### PR DESCRIPTION
Give Claude Code persistent project context (env setup, lint/test commands, structure, design principles) plus domain-scoped API guidance under .claude/rules/ (class expressions, ontology management, reasoning, syntax conversion, OWLAPI/SWRL, KG generation) so it doesn't need to re-explore the codebase each session.