### PR TITLE
feat: add get_dl_expressivity() for computing ontology DL expressivity

### DIFF
--- a/owlapy/__init__.py
+++ b/owlapy/__init__.py
@@ -1,4 +1,5 @@
 from .converter import owl_expression_to_sparql, owl_expression_to_sparql_with_confusion_matrix
+from .expressivity import get_dl_expressivity
 from .owl_reasoner_rdflib import RDFLibReasoner
 from .parser import dl_to_owl_expression, manchester_to_owl_expression
 from .render import owl_expression_to_dl, owl_expression_to_manchester
@@ -9,5 +10,6 @@ __all__ = [
     'owl_expression_to_dl', 'owl_expression_to_manchester',
     'dl_to_owl_expression', 'manchester_to_owl_expression',
     'owl_expression_to_sparql', 'owl_expression_to_sparql_with_confusion_matrix',
+    'get_dl_expressivity',
     'RDFLibReasoner'
 ]

--- a/owlapy/expressivity.py
+++ b/owlapy/expressivity.py
@@ -1,0 +1,93 @@
+"""Compute the DL (Description Logic) expressivity of a loaded ontology.
+
+Feature detection is delegated to OWLAPI's ``DLExpressivityChecker``
+(already bundled for the Java reasoners in ``owlapy/jar_dependencies/``),
+since its subsumption handling (e.g. full existential subsuming limited
+existential, qualified cardinality subsuming unqualified) is mature and
+battle-tested. The canonical DL name (e.g. ``"ALC"``, ``"SHIQ(D)"``) is
+assembled here rather than via OWLAPI's own ``getDescriptionLogicName()``,
+whose ``Construct.toString()`` returns internal debug labels
+(``"RRESTR"``, ``"CINT"``, ...) instead of standard DL letters.
+"""
+from owlapy.owl_ontology import SyncOntology
+
+__all__ = ['get_dl_expressivity']
+
+
+def get_dl_expressivity(ontology: SyncOntology) -> str:
+    """Compute the DL expressivity name of an ontology, e.g. ``"ALCHN(D)"``.
+
+    Args:
+        ontology: A :class:`~owlapy.owl_ontology.SyncOntology` instance.
+
+    Returns:
+        The standard Description Logic name for the ontology's expressivity.
+
+    Raises:
+        TypeError: If ``ontology`` is not backed by OWLAPI (only
+            :class:`~owlapy.owl_ontology.SyncOntology` is supported, since
+            it is the only ontology backend that exposes RBox axioms).
+    """
+    if not isinstance(ontology, SyncOntology):
+        raise TypeError(
+            "get_dl_expressivity() requires a SyncOntology (OWLAPI-backed); "
+            f"got {type(ontology).__name__}. Load the ontology with "
+            "owlapy.owl_ontology.SyncOntology instead."
+        )
+
+    # noinspection PyUnresolvedReferences
+    from org.semanticweb.owlapi.util import DLExpressivityChecker
+
+    checker = DLExpressivityChecker([ontology.owlapi_ontology])
+    constructs = {str(c.name()) for c in checker.getConstructs()}
+
+    has_complex_negation = "CONCEPT_COMPLEX_NEGATION" in constructs
+    has_union = "CONCEPT_UNION" in constructs
+    has_full_existential = "FULL_EXISTENTIAL" in constructs
+    has_role_hierarchy = "ROLE_HIERARCHY" in constructs
+    has_transitive = "ROLE_TRANSITIVE" in constructs
+    has_complex_roles = "ROLE_REFLEXIVITY_CHAINS" in constructs or "ROLE_COMPLEX" in constructs
+    has_nominals = "NOMINALS" in constructs
+    has_inverse = "ROLE_INVERSE" in constructs
+    has_functional = "F" in constructs
+    has_unqualified_cardinality = "N" in constructs
+    has_qualified_cardinality = "Q" in constructs
+    has_datatypes = "D" in constructs
+
+    # S is shorthand for ALC + transitive roles and replaces the AL[C] prefix.
+    if has_transitive:
+        name = "S"
+    else:
+        name = "AL"
+        if has_complex_negation:
+            name += "C"
+        else:
+            # U and E are redundant once C is present (De Morgan's laws).
+            if has_union:
+                name += "U"
+            if has_full_existential:
+                name += "E"
+
+    if has_role_hierarchy:
+        name += "H"
+    if has_complex_roles:
+        name += "R"
+    if has_nominals:
+        name += "O"
+    if has_inverse:
+        name += "I"
+
+    # Q (qualified cardinality) subsumes N (unqualified); show only one.
+    if has_qualified_cardinality:
+        name += "Q"
+    elif has_unqualified_cardinality:
+        name += "N"
+
+    # F (functional) is redundant once N/Q is present (functional == <=1).
+    if has_functional and not (has_unqualified_cardinality or has_qualified_cardinality):
+        name += "F"
+
+    if has_datatypes:
+        name += "(D)"
+
+    return name

--- a/owlapy/owl_ontology.py
+++ b/owlapy/owl_ontology.py
@@ -1368,6 +1368,11 @@ class SyncOntology(AbstractOWLOntology):
     def get_owlapi_ontology(self):
         return self.owlapi_ontology
 
+    def get_dl_expressivity(self) -> str:
+        """Compute the DL expressivity name of this ontology, e.g. "ALCHN(D)"."""
+        from owlapy.expressivity import get_dl_expressivity
+        return get_dl_expressivity(self)
+
     def get_ontology_id(self) -> OWLOntologyID:
         return self.mapper.map_(self.owlapi_ontology.getOntologyID())
 

--- a/tests/test_expressivity.py
+++ b/tests/test_expressivity.py
@@ -1,0 +1,32 @@
+import unittest
+
+from owlapy import get_dl_expressivity
+from owlapy.expressivity import get_dl_expressivity as get_dl_expressivity_direct
+from owlapy.owl_ontology import SyncOntology
+
+
+class TestExpressivity(unittest.TestCase):
+
+    def test_father_ontology_expressivity(self):
+        onto = SyncOntology("KGs/Family/father.owl")
+        self.assertEqual(get_dl_expressivity(onto), "ALC")
+
+    def test_biopax_ontology_expressivity(self):
+        onto = SyncOntology("KGs/Biopax/biopax.owl")
+        self.assertEqual(get_dl_expressivity(onto), "ALCHN(D)")
+
+    def test_top_level_and_submodule_exports_agree(self):
+        onto = SyncOntology("KGs/Family/father.owl")
+        self.assertEqual(get_dl_expressivity(onto), get_dl_expressivity_direct(onto))
+
+    def test_sync_ontology_convenience_method(self):
+        onto = SyncOntology("KGs/Family/father.owl")
+        self.assertEqual(onto.get_dl_expressivity(), "ALC")
+
+    def test_rejects_non_syncontology(self):
+        with self.assertRaises(TypeError):
+            get_dl_expressivity("not an ontology")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_expressivity.py
+++ b/tests/test_expressivity.py
@@ -14,6 +14,7 @@ class TestExpressivity(unittest.TestCase):
     def test_biopax_ontology_expressivity(self):
         onto = SyncOntology("KGs/Biopax/biopax.owl")
         self.assertEqual(get_dl_expressivity(onto), "ALCHN(D)")
+        self.assertEqual(onto.get_dl_expressivity(), "ALCHN(D)")
 
     def test_top_level_and_submodule_exports_agree(self):
         onto = SyncOntology("KGs/Family/father.owl")


### PR DESCRIPTION
Resolves #220. 

Computes the standard DL name (e.g. "ALC", "SHIQ(D)") for a loaded SyncOntology by delegating feature detection to OWLAPI's DLExpressivityChecker (already bundled for the Java reasoners) and assembling the canonical letter string in Python, since DLExpressivityChecker.getDescriptionLogicName() returns internal debug labels rather than standard DL notation on the bundled OWLAPI version.

Exposed both as a top-level owlapy.get_dl_expressivity(ontology) function and as SyncOntology.get_dl_expressivity(), matching existing library conventions.