### PR TITLE
fix: guard rdfs:comment batch generation against LLM call failures

### DIFF
--- a/owlapy/agen_kg/graph_extractor.py
+++ b/owlapy/agen_kg/graph_extractor.py
@@ -1509,13 +1509,20 @@ class GraphExtractor(dspy.Module, ABC, metaclass=GraphExtractorMeta):
         Returns:
             List[OWLAnnotationAssertionAxiom]:
                 One annotation assertion axiom per valid entity that received
-                a comment.
+                a comment. Returns an empty list if the LLM call for this batch
+                fails, so a single failed batch does not abort the rest of the
+                pipeline (e.g. already-generated entities/triples/labels).
         """
         iri_type_pairs: list[tuple[str, Literal["class", "property", "individual"]]] = [(iri.as_str(), entity_type) for iri, entity_type in entities_meta]
 
         valid_iri_set: set[str] = {iri.as_str() for iri, _ in entities_meta}
 
-        result = self.batch_rdfs_comment_generator(iri_type_pairs=iri_type_pairs, context=context)
+        try:
+            result = self.batch_rdfs_comment_generator(iri_type_pairs=iri_type_pairs, context=context)
+        except Exception as e:
+            if self.logging:
+                print(f"{self.__class__.__name__}: WARNING :: Failed to generate rdfs:comment annotations for batch, skipping: {e}")
+            return []
 
         axioms: list[OWLAnnotationAssertionAxiom] = []
 


### PR DESCRIPTION
## Context

Follow-up to #219 (rdfs:label / rdfs:comment annotation support).

`generate_batch_rdfs_comment_axioms()` calls the `batch_rdfs_comment_generator`
LLM predictor with no error handling. Every other LLM-touching step in
`GraphExtractor` (`_extract_entities_from_chunks`, `_extract_triples_from_chunks`,
`_incremental_merge_entities`, etc.) wraps its dspy call in `try/except` and
degrades gracefully on failure. This one didn't, so a single failed batch
(rate limit, transient network error, malformed LLM output) during the
rdfs:comment generation step — which runs last, right before `onto.save()` —
would raise and abort `generate_ontology()` entirely, discarding all
previously extracted entities, triples, types, and rdfs:label annotations.

## Change

Wrap the `batch_rdfs_comment_generator` call in `try/except`, matching the
existing resilience pattern: on failure, log a warning (when `self.logging`
is enabled) and return an empty axiom list for that batch instead of
propagating the exception. Other batches / the rest of the pipeline are
unaffected.

## Test plan

- [x] `ruff check owlapy/agen_kg/graph_extractor.py --line-length=200` passes
- [x] `PYTHONPATH=. pytest tests/test_owlapy_graph_extractor.py -p no:warnings` — 18/18 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NE7pMyNv2Jvx8cAdw58kyZ