### PR TITLE
test: increase coverage for TextChunker and DomainExamplesCache; fix chunking infinite loop

### DIFF
--- a/owlapy/agen_kg/chunking_models/simple_chunker.py
+++ b/owlapy/agen_kg/chunking_models/simple_chunker.py
@@ -213,12 +213,14 @@ class TextChunker:
 
             chunks.append(text[start:end].strip())
 
-            # Move start position with overlap
-            start = end - self.overlap if self.overlap > 0 else end
-
-            # Ensure we're making progress
-            if start >= text_length:
+            # Stop once this chunk reached the end of the text, otherwise
+            # start = end - overlap would never reach text_length and loop forever
+            if end >= text_length:
                 break
+
+            # Move start position with overlap, always making forward progress
+            next_start = end - self.overlap if self.overlap > 0 else end
+            start = next_start if next_start > start else end
 
         return chunks
 

--- a/tests/test_domain_examples_cache.py
+++ b/tests/test_domain_examples_cache.py
@@ -1,0 +1,100 @@
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from owlapy.agen_kg.domain_examples_cache import EXAMPLE_TYPE_MAPPING, DomainExamplesCache
+
+
+def _make_valid_examples():
+    return {key: f"example text for {key}" for key in EXAMPLE_TYPE_MAPPING.keys()}
+
+
+class TestDomainExamplesCache(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+        self.cache = DomainExamplesCache(cache_dir=self.tmp_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def test_init_creates_cache_dir_if_missing(self):
+        nested_dir = Path(self.tmp_dir) / "nested" / "cache"
+        self.assertFalse(nested_dir.exists())
+        DomainExamplesCache(cache_dir=str(nested_dir))
+        self.assertTrue(nested_dir.exists())
+
+    def test_init_defaults_to_cwd_when_no_dir_given(self):
+        cache = DomainExamplesCache()
+        self.assertEqual(cache.cache_dir, Path.cwd())
+
+    def test_sanitize_domain_name_lowercases_and_strips(self):
+        self.assertEqual(DomainExamplesCache._sanitize_domain_name("  Biology  "), "biology")
+
+    def test_sanitize_domain_name_replaces_special_chars(self):
+        self.assertEqual(DomainExamplesCache._sanitize_domain_name("Bio-Medical/Science!"), "bio_medical_science_")
+
+    def test_sanitize_domain_name_collapses_consecutive_underscores(self):
+        self.assertEqual(DomainExamplesCache._sanitize_domain_name("a   b"), "a_b")
+
+    def test_get_cache_file_path_uses_sanitized_name(self):
+        path = self.cache.get_cache_file_path("My Domain")
+        self.assertTrue(path.endswith("domain_examples_my_domain.json"))
+
+    def test_save_and_load_round_trip(self):
+        examples = _make_valid_examples()
+        self.assertTrue(self.cache.save_examples("biology", examples))
+        loaded = self.cache.load_examples("biology")
+        self.assertEqual(loaded, examples)
+
+    def test_save_examples_missing_key_fails(self):
+        incomplete = _make_valid_examples()
+        incomplete.pop("entity_extraction")
+        self.assertFalse(self.cache.save_examples("biology", incomplete))
+        self.assertFalse(self.cache.examples_exist("biology"))
+
+    def test_load_examples_returns_none_when_not_cached(self):
+        self.assertIsNone(self.cache.load_examples("nonexistent"))
+
+    def test_load_examples_returns_none_for_corrupted_json(self):
+        cache_file = self.cache._get_cache_file("broken")
+        cache_file.write_text("not valid json{", encoding="utf-8")
+        self.assertIsNone(self.cache.load_examples("broken"))
+
+    def test_load_examples_returns_none_when_missing_expected_key(self):
+        cache_file = self.cache._get_cache_file("partial")
+        cache_file.write_text(json.dumps({"entity_extraction": "only one"}), encoding="utf-8")
+        self.assertIsNone(self.cache.load_examples("partial"))
+
+    def test_examples_exist_true_and_false(self):
+        self.assertFalse(self.cache.examples_exist("chemistry"))
+        self.cache.save_examples("chemistry", _make_valid_examples())
+        self.assertTrue(self.cache.examples_exist("chemistry"))
+
+    def test_clear_domain_cache_removes_file(self):
+        self.cache.save_examples("physics", _make_valid_examples())
+        self.assertTrue(self.cache.examples_exist("physics"))
+        self.assertTrue(self.cache.clear_domain_cache("physics"))
+        self.assertFalse(self.cache.examples_exist("physics"))
+
+    def test_clear_domain_cache_nonexistent_domain_returns_true(self):
+        self.assertTrue(self.cache.clear_domain_cache("never_existed"))
+
+    def test_clear_all_caches_removes_every_file(self):
+        self.cache.save_examples("biology", _make_valid_examples())
+        self.cache.save_examples("chemistry", _make_valid_examples())
+        self.assertTrue(self.cache.clear_all_caches())
+        self.assertEqual(self.cache.list_cached_domains(), [])
+
+    def test_list_cached_domains_returns_sorted_names(self):
+        self.cache.save_examples("zoology", _make_valid_examples())
+        self.cache.save_examples("astronomy", _make_valid_examples())
+        self.assertEqual(self.cache.list_cached_domains(), ["astronomy", "zoology"])
+
+    def test_list_cached_domains_empty_when_no_cache_files(self):
+        self.assertEqual(self.cache.list_cached_domains(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_text_chunker.py
+++ b/tests/test_text_chunker.py
@@ -1,0 +1,176 @@
+import unittest
+
+from owlapy.agen_kg.chunking_models.simple_chunker import TextChunker
+
+
+class TestChunkTextBasics(unittest.TestCase):
+    """Test the top-level chunk_text dispatch and edge cases."""
+
+    def test_empty_text_returns_empty_list(self):
+        chunker = TextChunker()
+        self.assertEqual(chunker.chunk_text(""), [])
+
+    def test_text_shorter_than_chunk_size_returned_as_single_chunk(self):
+        chunker = TextChunker(chunk_size=1000)
+        text = "This is a short piece of text."
+        self.assertEqual(chunker.chunk_text(text), [text])
+
+    def test_unknown_strategy_raises_value_error(self):
+        chunker = TextChunker(strategy="unknown")
+        with self.assertRaises(ValueError):
+            chunker.chunk_text("x" * 10000)
+
+    def test_logging_enabled_does_not_raise(self):
+        chunker = TextChunker(chunk_size=50, overlap=0, strategy="fixed", enable_logging=True)
+        text = "word " * 50
+        chunks = chunker.chunk_text(text)
+        self.assertGreater(len(chunks), 1)
+
+
+class TestChunkBySentences(unittest.TestCase):
+    def test_splits_multiple_sentences_into_chunks(self):
+        chunker = TextChunker(chunk_size=60, overlap=0, strategy="sentence")
+        text = ("Sentence one is here. Sentence two follows now. "
+                "Sentence three comes next. Sentence four ends it.")
+        chunks = chunker.chunk_text(text)
+        self.assertGreater(len(chunks), 1)
+        # No chunk should exceed the configured size by a large margin
+        for chunk in chunks:
+            self.assertLessEqual(len(chunk), chunker.chunk_size + 20)
+
+    def test_no_sentence_boundaries_falls_back_to_paragraphs(self):
+        chunker = TextChunker(chunk_size=20, overlap=0, strategy="sentence")
+        text = "onelongwordwithoutandpunctuationatallxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        chunks = chunker.chunk_text(text)
+        self.assertGreater(len(chunks), 0)
+        self.assertEqual("".join(c.replace(" ", "") for c in chunks).replace(" ", ""),
+                          text.replace(" ", ""))
+
+    def test_overlap_included_between_chunks(self):
+        chunker = TextChunker(chunk_size=40, overlap=15, strategy="sentence")
+        text = ("Alpha sentence is short. Beta sentence is short too. "
+                "Gamma sentence follows here. Delta sentence ends the text.")
+        chunks = chunker.chunk_text(text)
+        self.assertGreater(len(chunks), 1)
+
+    def test_oversized_single_sentence_is_split_further(self):
+        chunker = TextChunker(chunk_size=30, overlap=0, strategy="sentence")
+        long_sentence = "Word " * 30 + "."
+        text = f"Short one. {long_sentence} Short two."
+        chunks = chunker.chunk_text(text)
+        self.assertGreater(len(chunks), 1)
+        for chunk in chunks:
+            self.assertLessEqual(len(chunk), chunker.chunk_size + 5)
+
+
+class TestChunkByParagraphs(unittest.TestCase):
+    def test_splits_multiple_paragraphs_into_chunks(self):
+        chunker = TextChunker(chunk_size=50, overlap=0, strategy="paragraph")
+        text = "Para one text here.\n\nPara two text here.\n\nPara three text here."
+        chunks = chunker.chunk_text(text)
+        self.assertGreater(len(chunks), 1)
+
+    def test_no_paragraph_boundaries_falls_back_to_fixed(self):
+        chunker = TextChunker(chunk_size=20, overlap=0, strategy="paragraph")
+        text = "a" * 100
+        chunks = chunker.chunk_text(text)
+        self.assertGreater(len(chunks), 1)
+
+    def test_overlap_keeps_last_paragraph_when_it_fits(self):
+        chunker = TextChunker(chunk_size=40, overlap=25, strategy="paragraph")
+        text = "Short para A.\n\nShort para B.\n\nShort para C.\n\nShort para D."
+        chunks = chunker.chunk_text(text)
+        self.assertGreater(len(chunks), 1)
+
+    def test_oversized_single_paragraph_is_split_by_sentences(self):
+        chunker = TextChunker(chunk_size=30, overlap=0, strategy="paragraph")
+        long_para = "This is sentence one. This is sentence two. This is sentence three."
+        text = f"Short para.\n\n{long_para}"
+        chunks = chunker.chunk_text(text)
+        self.assertGreater(len(chunks), 1)
+
+
+class TestChunkFixed(unittest.TestCase):
+    def test_fixed_strategy_splits_at_word_boundaries(self):
+        chunker = TextChunker(chunk_size=20, overlap=0, strategy="fixed")
+        text = "one two three four five six seven eight nine ten"
+        chunks = chunker.chunk_text(text)
+        self.assertGreater(len(chunks), 1)
+        for chunk in chunks:
+            self.assertLessEqual(len(chunk), 20)
+
+    def test_fixed_strategy_with_overlap_progresses(self):
+        chunker = TextChunker(chunk_size=20, overlap=5, strategy="fixed")
+        text = "word " * 20
+        chunks = chunker.chunk_text(text)
+        self.assertGreater(len(chunks), 1)
+
+    def test_fixed_strategy_terminates_when_final_chunk_reaches_end_of_text(self):
+        # Regression test: with overlap > 0, once the cursor's fixed-size window
+        # reaches the end of the text, start = end - overlap must not loop forever
+        # re-emitting the same trailing slice. See _chunk_fixed.
+        chunker = TextChunker(chunk_size=3000, overlap=200, strategy="fixed")
+        text = "x" * 50000
+        chunks = chunker.chunk_text(text)
+        self.assertGreater(len(chunks), 1)
+        self.assertLess(len(chunks), 100)
+
+    def test_fixed_strategy_terminates_with_overlap_close_to_chunk_size(self):
+        chunker = TextChunker(chunk_size=20, overlap=19, strategy="fixed")
+        text = "word " * 50
+        chunks = chunker.chunk_text(text)
+        self.assertGreater(len(chunks), 1)
+        self.assertLess(len(chunks), 500)
+
+    def test_fixed_strategy_no_space_breaks_at_chunk_size(self):
+        chunker = TextChunker(chunk_size=10, overlap=0, strategy="fixed")
+        text = "a" * 35
+        chunks = chunker.chunk_text(text)
+        self.assertTrue(all(len(c) <= 10 for c in chunks))
+        self.assertEqual("".join(chunks), text)
+
+
+class TestEstimateTokens(unittest.TestCase):
+    def test_default_ratio(self):
+        chunker = TextChunker()
+        self.assertEqual(chunker.estimate_tokens("a" * 40), 10)
+
+    def test_custom_ratio(self):
+        chunker = TextChunker()
+        self.assertEqual(chunker.estimate_tokens("a" * 40, chars_per_token=2), 20)
+
+
+class TestGetChunkInfo(unittest.TestCase):
+    def test_info_fields_for_short_text(self):
+        chunker = TextChunker(chunk_size=1000)
+        text = "A short bit of text."
+        info = chunker.get_chunk_info(text)
+        self.assertEqual(info["total_chars"], len(text))
+        self.assertEqual(info["num_chunks"], 1)
+        self.assertEqual(info["chunk_sizes"], [len(text)])
+        self.assertEqual(info["avg_chunk_size"], len(text))
+        self.assertEqual(info["strategy"], "sentence")
+        self.assertEqual(info["configured_chunk_size"], 1000)
+        self.assertEqual(info["configured_overlap"], 200)
+
+    def test_info_for_empty_text_has_zero_avg(self):
+        chunker = TextChunker()
+        info = chunker.get_chunk_info("")
+        self.assertEqual(info["num_chunks"], 0)
+        self.assertEqual(info["avg_chunk_size"], 0)
+
+
+class TestCalculateChunkSizeForModel(unittest.TestCase):
+    def test_default_parameters(self):
+        size = TextChunker.calculate_chunk_size_for_model(8000, 2000)
+        # (8000 - 2000) * 0.8 * 4
+        self.assertEqual(size, 19200)
+
+    def test_custom_chars_per_token(self):
+        size = TextChunker.calculate_chunk_size_for_model(4000, 1000, chars_per_token=3)
+        # (4000 - 1000) * 0.8 * 3
+        self.assertEqual(size, 7200)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Added `tests/test_text_chunker.py` (22 tests) covering `TextChunker`'s sentence/paragraph/fixed chunking strategies, overlap handling, oversized-sentence/paragraph fallback, `estimate_tokens`, `get_chunk_info`, and `calculate_chunk_size_for_model`. Coverage for `simple_chunker.py`: **15% → 96%**.
- Added `tests/test_domain_examples_cache.py` (18 tests) covering `DomainExamplesCache` save/load round-trips, validation of missing/corrupted cache data, domain-name sanitization, and cache clearing/listing. Coverage for `domain_examples_cache.py`: **23% → 89%**.
- **Bug fix**: while writing tests for `_chunk_fixed`, found and fixed a real infinite-loop bug. With `overlap > 0`, once the fixed-size cursor's window reaches the end of the text, `start = end - overlap` never satisfies `start >= text_length`, so the loop re-emits the same trailing slice forever, growing the `chunks` list unboundedly (observed ~50GB RSS before being killed). This reproduces on the module's own default config (`chunk_size=3000, overlap=200`) whenever fixed-chunking runs to completion — i.e. on the fallback path any time a single sentence/paragraph exceeds `chunk_size`. Fixed by breaking once a chunk reaches `text_length`, and otherwise guaranteeing the cursor always advances.

## Test plan
- [x] `ruff check owlapy tests/test_text_chunker.py tests/test_domain_examples_cache.py --line-length=200` — clean
- [x] `pytest tests/test_text_chunker.py tests/test_domain_examples_cache.py` — 40/40 passed
- [x] Full suite: `pytest --ignore=tests/test_z_do_last_ebr_retrieval.py -p no:warnings` — 631 passed (591 baseline + 40 new), no regressions
- [x] Manually reproduced the infinite loop pre-fix with a 5s `timeout` (exit 124), confirmed fixed post-fix on both the minimal repro and the module's default config against a 50k-char input