### PR TITLE
feat: implement OWLAnonymousIndividual and map it through OWLAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `rdfs:label` annotations, deterministically computed from entity IRIs
   - `rdfs:comment` annotations, generated via LLM
 - Test coverage for `TextChunker` and `DomainExamplesCache` in `agen_kg` (#224)
+- `OWLAnonymousIndividual` class for representing anonymous (blank-node) individuals, with a `NodeID` helper for node-id generation/normalization, and OWLAPI bridge mapping so anonymous individuals no longer break `get_abox_axioms()`/class/property assertion retrieval (#217)
 
 ### Fixed
 - Guarded `rdfs:comment` batch generation against LLM call failures, so a single failed batch no longer aborts the whole ontology generation pipeline (#223)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,11 @@ branches. Open PRs against `develop`, not `main`. Release process (version bump 
 both files, CHANGELOG.md update, merge develop → main, tag, build, `twine upload`)
 is documented in `.github/copilot-instructions.md` if you're driving a release.
 
+Update `CHANGELOG.md`'s `[Unreleased]` section (under `Added`/`Changed`/`Fixed` as
+appropriate, referencing the PR/issue number) as part of implementing any
+user-facing feature or fix — don't wait until release to record it. Only move
+`[Unreleased]` entries into a new dated version section during an actual release.
+
 ## Rules
 
 Domain-specific API patterns and constraints load automatically from

--- a/owlapy/owl_individual.py
+++ b/owlapy/owl_individual.py
@@ -1,8 +1,9 @@
 """OWL Individuals"""
 from abc import ABCMeta
-from typing import Final, Union
+from typing import ClassVar, Final, Optional, Union
 
 from .iri import IRI
+from .owl_annotation import OWLAnnotationSubject, OWLAnnotationValue
 from .owl_object import OWLEntity, OWLObject
 
 
@@ -10,6 +11,33 @@ class OWLIndividual(OWLObject, metaclass=ABCMeta):
     """Represents a named or anonymous individual."""
     __slots__ = ()
     pass
+
+
+class NodeID:
+    """Generates and normalizes the node IDs used to identify :class:`OWLAnonymousIndividual` instances,
+    loosely modeled after OWLAPI's ``org.semanticweb.owlapi.model.NodeID``.
+
+    Node IDs are local to an ontology document: they let one distinguish different anonymous individuals
+    without asserting any particular identity for them.
+    """
+    __slots__ = ()
+    _counter: ClassVar[int] = 0
+
+    @staticmethod
+    def get_node_id(id_: Optional[str] = None) -> str:
+        """Normalize a node id, generating a fresh, unused one if none is given.
+
+        Args:
+            id_: A string identifying an anonymous individual, optionally prefixed with "_:" (as blank node
+                labels are written in Turtle/N-Triples). If None, a fresh node id is generated.
+
+        Returns:
+            The normalized node id string, without a "_:" prefix.
+        """
+        if id_ is None:
+            NodeID._counter += 1
+            return f"genid-{NodeID._counter}"
+        return id_[2:] if id_.startswith("_:") else id_
 
 
 class OWLNamedIndividual(OWLIndividual, OWLEntity):
@@ -45,3 +73,56 @@ class OWLNamedIndividual(OWLIndividual, OWLEntity):
     @property
     def remainder(self):
         return self._iri.remainder
+
+
+class OWLAnonymousIndividual(OWLIndividual, OWLAnnotationSubject, OWLAnnotationValue):
+    """Anonymous individuals are identified using a node ID rather than an IRI. Node IDs are local to an
+    ontology document: they allow different anonymous individuals to be distinguished from one another
+    without asserting any particular identity for them.
+
+    (https://www.w3.org/TR/owl2-syntax/#Anonymous_Individuals)
+    """
+    __slots__ = '_node_id'
+    type_index: Final = 1006
+
+    _node_id: str
+
+    def __init__(self, node_id: Optional[str] = None):
+        """Gets an instance of OWLAnonymousIndividual identified by the given node id, generating a fresh,
+        unused one if none is given.
+
+        Args:
+            node_id: A string identifying this anonymous individual, or None to generate a fresh one.
+
+        Returns:
+            An OWLAnonymousIndividual identified by the given (or a freshly generated) node id.
+        """
+        self._node_id = NodeID.get_node_id(node_id)
+
+    @property
+    def node_id(self) -> str:
+        return self._node_id
+
+    @property
+    def str(self) -> str:
+        return self.to_string_id()
+
+    def to_string_id(self) -> str:
+        return f"_:{self._node_id}"
+
+    def is_anonymous(self) -> bool:
+        return True
+
+    def as_anonymous_individual(self) -> 'OWLAnonymousIndividual':
+        return self
+
+    def __eq__(self, other):
+        if type(other) is type(self):
+            return self._node_id == other._node_id
+        return False
+
+    def __hash__(self):
+        return hash(("OWLAnonymousIndividual", self._node_id))
+
+    def __repr__(self):
+        return f"OWLAnonymousIndividual({self._node_id!r})"

--- a/owlapy/owlapi_mapper.py
+++ b/owlapy/owlapi_mapper.py
@@ -71,7 +71,7 @@ from owlapy.owl_axiom import (
 )
 from owlapy.owl_data_ranges import OWLDataComplementOf, OWLDataIntersectionOf, OWLDataUnionOf, OWLNaryDataRange
 from owlapy.owl_datatype import OWLDatatype
-from owlapy.owl_individual import OWLNamedIndividual
+from owlapy.owl_individual import OWLAnonymousIndividual, OWLNamedIndividual
 from owlapy.owl_literal import NegativeIntegerOWLDatatype, NonNegativeIntegerOWLDatatype, NonPositiveIntegerOWLDatatype, OWLLiteral, PositiveIntegerOWLDatatype
 from owlapy.owl_ontology import OWLOntologyID
 from owlapy.owl_property import OWLDataProperty, OWLObjectInverseOf, OWLObjectProperty
@@ -83,6 +83,7 @@ if not jpype.isJVMStarted():
 from java.util import ArrayList, Collections, LinkedHashSet, List, Optional, Set
 from java.util.stream import Stream
 from org.semanticweb.owlapi.model import IRI as owlapi_IRI
+from org.semanticweb.owlapi.model import NodeID as owlapi_NodeID
 from org.semanticweb.owlapi.model import OWLOntologyID as owlapi_OWLOntologyID
 from org.semanticweb.owlapi.vocab import OWLFacet as owlapi_OWLFacet
 from uk.ac.manchester.cs.owl.owlapi import (
@@ -92,6 +93,7 @@ from uk.ac.manchester.cs.owl.owlapi import (
     OWLAnnotationPropertyDomainAxiomImpl,
     OWLAnnotationPropertyImpl,
     OWLAnnotationPropertyRangeAxiomImpl,
+    OWLAnonymousIndividualImpl,
     OWLAsymmetricObjectPropertyAxiomImpl,
     OWLClassAssertionAxiomImpl,
     OWLClassImpl,
@@ -220,6 +222,14 @@ class OWLAPIMapper:
     @map_.register(OWLClassImpl)
     def _(self, e):
         return init(e)(self.map_(e.getIRI()))
+
+    @map_.register(OWLAnonymousIndividual)
+    def _(self, e):
+        return OWLAnonymousIndividualImpl(owlapi_NodeID.getNodeID(e.node_id))
+
+    @map_.register(OWLAnonymousIndividualImpl)
+    def _(self, e):
+        return OWLAnonymousIndividual(str(e.getID().getID()))
 
     @map_.register(OWL2DatatypeImpl)
     def _(self, e):

--- a/tests/test_owl_anonymous_individual.py
+++ b/tests/test_owl_anonymous_individual.py
@@ -1,0 +1,100 @@
+import os
+import tempfile
+import unittest
+
+from owlapy.owl_axiom import OWLClassAssertionAxiom, OWLObjectPropertyAssertionAxiom
+from owlapy.owl_individual import OWLAnonymousIndividual, OWLNamedIndividual
+from owlapy.owl_ontology import SyncOntology
+
+# Minimal reproduction from https://github.com/dice-group/owlapy/issues/217
+ONTOLOGY_WITH_ANONYMOUS_INDIVIDUAL = """
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix ex: <http://example.org/> .
+
+<http://example.org/ontology> a owl:Ontology ;
+    rdfs:label "Example Ontology with Anonymous Individual" .
+
+ex:Person a owl:Class ;
+    rdfs:label "Person" .
+
+ex:knows a owl:ObjectProperty ;
+    rdfs:label "knows" ;
+    rdfs:domain ex:Person ;
+    rdfs:range ex:Person .
+
+ex:Alice a ex:Person ;
+    rdfs:label "Alice" ;
+    ex:knows [ a ex:Person ] .
+"""
+
+
+class TestOWLAnonymousIndividual(unittest.TestCase):
+    """Unit tests for the OWLAnonymousIndividual class itself (no JVM involved)."""
+
+    def test_generates_distinct_fresh_node_ids(self):
+        a = OWLAnonymousIndividual()
+        b = OWLAnonymousIndividual()
+        self.assertNotEqual(a, b)
+
+    def test_same_explicit_node_id_is_equal(self):
+        a = OWLAnonymousIndividual("b0")
+        b = OWLAnonymousIndividual("b0")
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+
+    def test_strips_blank_node_prefix(self):
+        a = OWLAnonymousIndividual("_:b0")
+        b = OWLAnonymousIndividual("b0")
+        self.assertEqual(a, b)
+        self.assertEqual(a.node_id, "b0")
+
+    def test_is_anonymous(self):
+        self.assertTrue(OWLAnonymousIndividual("b0").is_anonymous())
+
+    def test_not_equal_to_named_individual(self):
+        self.assertNotEqual(OWLAnonymousIndividual("b0"), OWLNamedIndividual("http://example.org/b0"))
+
+
+class TestOntologyWithAnonymousIndividual(unittest.TestCase):
+    """Regression test for issue #217: loading an ontology containing an anonymous
+    individual used to crash get_abox_axioms() with a functools.singledispatch error
+    while mapping OWLAnonymousIndividualImpl through the OWLAPI bridge."""
+
+    def setUp(self):
+        fd, self.ttl_path = tempfile.mkstemp(suffix=".ttl")
+        with os.fdopen(fd, "w") as f:
+            f.write(ONTOLOGY_WITH_ANONYMOUS_INDIVIDUAL)
+
+    def tearDown(self):
+        os.remove(self.ttl_path)
+
+    def test_get_abox_axioms_does_not_raise(self):
+        ontology = SyncOntology(self.ttl_path)
+        abox_axioms = list(ontology.get_abox_axioms())
+        self.assertEqual(len(abox_axioms), 3)
+
+    def test_anonymous_individual_is_consistent_across_axioms(self):
+        ontology = SyncOntology(self.ttl_path)
+        abox_axioms = list(ontology.get_abox_axioms())
+
+        class_assertions = [a for a in abox_axioms if isinstance(a, OWLClassAssertionAxiom)]
+        object_property_assertions = [a for a in abox_axioms if isinstance(a, OWLObjectPropertyAssertionAxiom)]
+
+        anonymous_class_assertions = [a for a in class_assertions if a.get_individual().is_anonymous()]
+        self.assertEqual(len(anonymous_class_assertions), 1)
+        anonymous_individual = anonymous_class_assertions[0].get_individual()
+        self.assertIsInstance(anonymous_individual, OWLAnonymousIndividual)
+        self.assertEqual(anonymous_class_assertions[0].get_class_expression(),
+                         next(a for a in class_assertions if not a.get_individual().is_anonymous()).get_class_expression())
+
+        self.assertEqual(len(object_property_assertions), 1)
+        knows_axiom = object_property_assertions[0]
+        self.assertEqual(knows_axiom.get_subject(), OWLNamedIndividual("http://example.org/Alice"))
+        # The object of ex:knows must be the very same anonymous individual asserted to be a Person.
+        self.assertEqual(knows_axiom.get_object(), anonymous_individual)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Anonymous (blank-node) individuals had no owlapy representation, so loading an ontology containing one (e.g. `ex:knows [ a ex:Person ]`) crashed with a functools.singledispatch KeyError/RuntimeError while mapping OWLAnonymousIndividualImpl from the OWLAPI bridge, aborting get_abox_axioms() and friends.

Add OWLAnonymousIndividual (owl_individual.py), identified by a node id via a small NodeID helper (owlapi's org.semanticweb.owlapi.model.NodeID analogue) rather than an IRI, implementing both OWLAnnotationSubject and OWLAnnotationValue like IRI/OWLLiteral do. Register the Java <-> Python mapping in OWLAPIMapper so it round-trips through class/object/data property assertions, (un)equal-individuals axioms and annotation assertions without further changes, since those all delegate to map_() generically.

Add tests/test_owl_anonymous_individual.py, covering OWLAnonymousIndividual equality/hashing/node-id handling directly, and a regression test built from the exact ontology in issue #217 verifying get_abox_axioms() no longer raises and that the anonymous individual is mapped consistently across the class and object-property assertions that reference it.

Fixes #217