### PR TITLE
docs: fix widespread verified bugs in markdown_docs

### DIFF
--- a/markdown_docs/01_getting_started.md
+++ b/markdown_docs/01_getting_started.md
@@ -66,7 +66,7 @@ ontology = SyncOntology("http://example.com/ontology.owl")
 ### 2. Create a Reasoner
 
 ```python
-from owlapy.owl_reasoner import RDFLibReasoner
+from owlapy.owl_reasoner_rdflib import RDFLibReasoner
 
 # Pure Python reasoner (recommended for most use cases)
 reasoner = RDFLibReasoner(ontology)
@@ -134,7 +134,7 @@ print(f"Manchester: {manchester}")
 
 ```python
 from owlapy.owl_ontology import SyncOntology
-from owlapy.owl_reasoner import RDFLibReasoner
+from owlapy.owl_reasoner_rdflib import RDFLibReasoner
 from owlapy.class_expression import (
     OWLClass,
     OWLObjectSomeValuesFrom,

--- a/markdown_docs/02_core_concepts.md
+++ b/markdown_docs/02_core_concepts.md
@@ -78,12 +78,11 @@ has_name = OWLDataProperty("http://example.com/onto#hasName")
 Literals are data values (strings, numbers, dates, etc.).
 
 ```python
-from owlapy.owl_literal import OWLLiteral
-from owlapy.owl_datatype import IntegerOWLDatatype, DoubleOWLDatatype, StringOWLDatatype
+from owlapy.owl_literal import OWLLiteral, IntegerOWLDatatype, DoubleOWLDatatype, StringOWLDatatype
 
-age = OWLLiteral(value=25, datatype=IntegerOWLDatatype)
-height = OWLLiteral(value=1.75, datatype=DoubleOWLDatatype)
-name = OWLLiteral(value="John", datatype=StringOWLDatatype)
+age = OWLLiteral(25, IntegerOWLDatatype)
+height = OWLLiteral(1.75, DoubleOWLDatatype)
+name = OWLLiteral("John", StringOWLDatatype)
 ```
 
 ### 3. Class Expressions
@@ -154,11 +153,11 @@ from owlapy.class_expression import (
     OWLObjectExactCardinality
 )
 
-# ≥2 hasChild (at least 2 children)
-at_least_two_children = OWLObjectMinCardinality(2, has_child)
+# ≥2 hasChild.⊤ (at least 2 children) -- filler is required, OWLThing for "any"
+at_least_two_children = OWLObjectMinCardinality(2, has_child, OWLThing)
 
-# ≤1 hasSpouse (at most 1 spouse)
-at_most_one_spouse = OWLObjectMaxCardinality(1, has_spouse)
+# ≤1 hasSpouse.⊤ (at most 1 spouse)
+at_most_one_spouse = OWLObjectMaxCardinality(1, has_spouse, OWLThing)
 
 # =3 hasChild.Male (exactly 3 male children)
 exactly_three_sons = OWLObjectExactCardinality(3, has_child, male)
@@ -251,7 +250,7 @@ from owlapy.owl_reasoner import StructuralReasoner
 reasoner = StructuralReasoner(ontology)
 
 # RDFLibReasoner - Pure Python, SPARQL-based, no circular dependencies
-from owlapy.owl_reasoner import RDFLibReasoner
+from owlapy.owl_reasoner_rdflib import RDFLibReasoner
 reasoner = RDFLibReasoner(ontology)
 
 # SyncReasoner - Complete OWL 2 DL reasoning, Java-based
@@ -362,10 +361,10 @@ ontology.add_axiom(disjoint)
 ### Pattern 3: Property Chains
 
 ```python
-from owlapy.owl_axiom import OWLSubPropertyChainOfAxiom
+from owlapy.owl_axiom import OWLSubPropertyChainAxiom
 
-# hasGrandparent ← hasParent ∘ hasParent
-chain = OWLSubPropertyChainOfAxiom([has_parent, has_parent], has_grandparent)
+# hasParent ∘ hasParent ⊑ hasGrandparent
+chain = OWLSubPropertyChainAxiom([has_parent, has_parent], has_grandparent)
 ontology.add_axiom(chain)
 ```
 

--- a/markdown_docs/03_ontology_management.md
+++ b/markdown_docs/03_ontology_management.md
@@ -103,17 +103,20 @@ onto = safe_load_ontology("family.owl")
 ```python
 # RDF/XML format (default)
 onto.save("output.owl")
-onto.save("output.owl", format="rdfxml")
+onto.save("output.owl", document_format="rdfxml")
 
-# Turtle format
-onto.save("output.ttl", format="turtle")
+# Turtle format (OWL API writer)
+onto.save("output.ttl", document_format="turtle")
 
-# N-Triples format
-onto.save("output.nt", format="ntriples")
+# N-Triples format (rdflib writer)
+onto.save("output.nt", document_format="ntriples")
 
-# N3 format
-onto.save("output.n3", format="n3")
+# N3 format (rdflib writer)
+onto.save("output.n3", document_format="n3")
 ```
+
+`document_format` accepts many more values (`"owlxml"`, `"functional"`, `"manchester"`,
+`"trig"`, `"json-ld"`, ...) — see `SyncOntology.save()`'s docstring for the full table.
 
 ### Save with Compression
 
@@ -126,6 +129,27 @@ with open("ontology.owl", "rb") as f_in:
     with gzip.open("ontology.owl.gz", "wb") as f_out:
         f_out.writelines(f_in)
 ```
+
+### Prefix Management (`SyncOntology` only)
+
+By default, entities from namespaces owlapy doesn't already know about (`owl:`, `rdf:`,
+`rdfs:`, `xsd:`, and the ontology's own IRI) serialize as full IRIs instead of a short
+`prefix:name`. Declare a prefix to get the abbreviated form back:
+
+```python
+onto.set_prefix("foaf", "http://xmlns.com/foaf/0.1/")
+
+onto.get_prefixes()
+# {"owl": "...", "rdf": "...", "rdfs": "...", "xsd": "...", "foaf": "http://xmlns.com/foaf/0.1/"}
+
+onto.remove_prefix("foaf")  # back to full IRIs on the next save()
+```
+
+Prefixes are honoured by `save()` for both the OWL API–backed formats that support them
+(RDF/XML, OWL/XML, Turtle, Functional Syntax, Manchester Syntax) and the rdflib-backed
+formats (`turtle2`, `n3`, `trig`, `json-ld`). `set_prefix`/`remove_prefix` raise
+`ValueError` if the ontology's current document format doesn't support prefixes at all
+(LaTeX, DL Syntax, KRSS2, OBO).
 
 ## Inspecting Ontologies
 
@@ -330,12 +354,13 @@ print(f"Found {len(students)} students")
 ```python
 from owlapy.util_owl_static_funcs import csv_to_rdf_kg
 
-# Convert CSV file to RDF knowledge graph
+# Convert CSV file to RDF knowledge graph.
+# Each row becomes an individual; each column becomes a data property named after
+# the column header, scoped under the given namespace.
 csv_to_rdf_kg(
-    csv_file="data.csv",
-    output_file="knowledge_graph.owl",
+    path_csv="data.csv",
+    path_kg="knowledge_graph.owl",
     namespace="http://example.com/data#",
-    class_name="DataPoint"
 )
 ```
 
@@ -357,8 +382,7 @@ from owlapy.class_expression import OWLClass
 from owlapy.owl_individual import OWLNamedIndividual
 from owlapy.owl_property import OWLDataProperty
 from owlapy.owl_axiom import OWLClassAssertionAxiom, OWLDataPropertyAssertionAxiom
-from owlapy.owl_literal import OWLLiteral
-from owlapy.owl_datatype import IntegerOWLDatatype, StringOWLDatatype
+from owlapy.owl_literal import OWLLiteral, IntegerOWLDatatype, StringOWLDatatype
 
 NS = "http://example.com/university#"
 
@@ -430,7 +454,7 @@ stats = ontology_statistics(onto)
 ### Check for Empty Classes
 
 ```python
-from owlapy.owl_reasoner import RDFLibReasoner
+from owlapy.owl_reasoner_rdflib import RDFLibReasoner
 
 def find_empty_classes(onto):
     """Find classes with no instances."""

--- a/markdown_docs/05_reasoning.md
+++ b/markdown_docs/05_reasoning.md
@@ -20,7 +20,7 @@ Pure Python reasoner using RDFLib and SPARQL queries. No circular dependencies, 
 
 ```python
 from owlapy.owl_ontology import SyncOntology
-from owlapy.owl_reasoner import RDFLibReasoner
+from owlapy.owl_reasoner_rdflib import RDFLibReasoner
 from owlapy.class_expression import OWLClass
 
 # Load ontology
@@ -118,6 +118,14 @@ finally:
     stopJVM()
 ```
 
+`instances()` (and `is_entailed()`, `create_axiom_justifications()`) accept a `timeout`
+in seconds (default 1000) and cooperatively cancel the underlying Java reasoning task if
+it's exceeded, returning whatever partial results were already found rather than hanging:
+
+```python
+instances = list(reasoner.instances(male, timeout=30))
+```
+
 ### Advanced Features
 
 #### Consistency Checking
@@ -136,41 +144,56 @@ stopJVM()
 
 #### Infer and Save New Axioms
 
-```python
-from owlapy.util_owl_static_funcs import infer_axioms_and_save
+`infer_axioms_and_save()` is a method on `SyncReasoner` itself (not a standalone
+function) -- it materializes inferred axioms via the OWL API's `InferredOntologyGenerator`
+and saves them onto the reasoner's own ontology.
 
+```python
 startJVM()
 
-# Infer axioms and save to new file
-infer_axioms_and_save(
-    ontology_path="family.owl",
-    reasoner_name="HermiT",
+reasoner = SyncReasoner("family.owl", reasoner="HermiT")
+
+# Infer new class assertions and save to a new file
+reasoner.infer_axioms_and_save(
     output_path="inferred_family.owl",
-    output_format="rdfxml"
+    output_format="rdfxml",
+    inference_types=["InferredClassAssertionAxiomGenerator"],
 )
 
 stopJVM()
 ```
 
+Other `inference_types` include `"InferredSubClassAxiomGenerator"`,
+`"InferredDisjointClassesAxiomGenerator"`, `"InferredEquivalentClassAxiomGenerator"`, and
+more -- see the method's docstring for the full list. A shortcut for the most common case:
+`reasoner.generate_and_save_inferred_class_assertion_axioms(output="inferred.ttl")`.
+
 #### Get Justifications (Why is this true?)
+
+Justifications are generated directly on the reasoner via `create_axiom_justifications()`
+(there is no `get_justifications()` on the ontology):
 
 ```python
 from owlapy.owl_axiom import OWLSubClassOfAxiom
 
 startJVM()
-reasoner = SyncReasoner(onto, "HermiT")
+reasoner = SyncReasoner(onto, reasoner="HermiT")
 
-# Why is Student a subclass of Person?
+# Why is Student a subclass of Person? (axiom must actually be entailed)
 axiom = OWLSubClassOfAxiom(student, person)
-justifications = reasoner.get_root_ontology().get_justifications(axiom)
+justifications = reasoner.create_axiom_justifications(axiom, n_max_justifications=10)
 
 for i, justification in enumerate(justifications, 1):
     print(f"Justification {i}:")
     for ax in justification:
         print(f"  - {ax}")
-        
+
 stopJVM()
 ```
+
+`create_laconic_axiom_justifications()` has the same signature but returns minimized
+("laconic") justifications. Both accept a `timeout` (seconds, default 1000) for
+cooperative cancellation of long-running searches.
 
 ### Choosing a Java Reasoner
 
@@ -248,12 +271,12 @@ ages = list(reasoner.data_property_values(john, has_age))
 ### Equivalence and Disjointness
 
 ```python
-# Check if classes are equivalent
-are_equiv = reasoner.equivalent_classes(male, 
-    OWLObjectIntersectionOf([person, OWLObjectComplementOf(female)]))
+# equivalent_classes()/disjoint_classes() take a single class expression and return
+# everything equivalent/disjoint to it -- check membership to answer "are X and Y ...?"
+not_female = OWLObjectComplementOf(female)
+are_equiv = male in reasoner.equivalent_classes(not_female)
 
-# Check if classes are disjoint
-are_disjoint = reasoner.disjoint_classes(male, female)
+are_disjoint = female in reasoner.disjoint_classes(male)
 ```
 
 ## Performance Optimization
@@ -311,7 +334,7 @@ stopJVM()
 
 ```python
 from owlapy.owl_ontology import SyncOntology
-from owlapy.owl_reasoner import RDFLibReasoner
+from owlapy.owl_reasoner_rdflib import RDFLibReasoner
 from owlapy.class_expression import *
 from owlapy.owl_property import OWLObjectProperty
 

--- a/markdown_docs/08_common_patterns.md
+++ b/markdown_docs/08_common_patterns.md
@@ -78,6 +78,7 @@ for axiom in axioms:
 
 ```python
 from owlapy.class_expression import *
+from owlapy.class_expression import OWLThing  # not exported by * (excluded from __all__)
 from owlapy.owl_property import OWLObjectProperty
 
 NS = "http://example.com/onto#"
@@ -89,11 +90,11 @@ def cls(name: str) -> OWLClass:
 def prop(name: str) -> OWLObjectProperty:
     return OWLObjectProperty(NS + name)
 
-# Build: Teacher ⊓ (∃ teaches.Graduate) ⊓ (≥2 hasPublication)
+# Build: Teacher ⊓ (∃ teaches.Graduate) ⊓ (≥2 hasPublication.⊤)
 expression = OWLObjectIntersectionOf([
     cls("Teacher"),
     OWLObjectSomeValuesFrom(prop("teaches"), cls("Graduate")),
-    OWLObjectMinCardinality(2, prop("hasPublication"))
+    OWLObjectMinCardinality(2, prop("hasPublication"), OWLThing)
 ])
 ```
 
@@ -164,7 +165,8 @@ simplified = simplifier.simplify(complex_expr)
 ### Pattern: Reasoner Factory
 
 ```python
-from owlapy.owl_reasoner import RDFLibReasoner, StructuralReasoner, SyncReasoner
+from owlapy.owl_reasoner_rdflib import RDFLibReasoner
+from owlapy.owl_reasoner import StructuralReasoner, SyncReasoner
 from owlapy.static_funcs import startJVM, stopJVM
 
 class ReasonerFactory:
@@ -314,13 +316,12 @@ expr = parse_expression(user_input, "http://example.com/onto#")
 ```python
 from owlapy.util_owl_static_funcs import csv_to_rdf_kg
 
-# Convert CSV to RDF
+# Convert CSV to RDF: each row becomes an individual, each column becomes a data
+# property named after the column header, scoped under `namespace`.
 csv_to_rdf_kg(
-    csv_file="data.csv",
-    output_file="knowledge_graph.owl",
+    path_csv="data.csv",
+    path_kg="knowledge_graph.owl",
     namespace="http://example.com/data#",
-    class_name="DataPoint",
-    delimiter=","
 )
 ```
 
@@ -332,8 +333,7 @@ from owlapy.owl_axiom import (
     OWLObjectPropertyAssertionAxiom,
     OWLDataPropertyAssertionAxiom
 )
-from owlapy.owl_literal import OWLLiteral
-from owlapy.owl_datatype import IntegerOWLDatatype
+from owlapy.owl_literal import OWLLiteral, IntegerOWLDatatype
 
 def add_individual_from_dict(onto, ind_data: dict, namespace: str):
     """Add individual with properties from dictionary."""

--- a/markdown_docs/09_api_reference.md
+++ b/markdown_docs/09_api_reference.md
@@ -82,7 +82,9 @@ SyncOntology(iri: IRI)
 - `data_properties_in_signature() -> Iterable[OWLDataProperty]` - Get all data properties
 - `add_axiom(axiom: OWLAxiom)` - Add axiom to ontology
 - `remove_axiom(axiom: OWLAxiom)` - Remove axiom
-- `save(path: str, format: str = 'rdfxml')` - Save ontology
+- `save(path: str, document_format: str = None)` - Save ontology (keeps current format if `document_format` is omitted; see the format table in `03_ontology_management.md`)
+- `get_dl_expressivity() -> str` - Compute the DL expressivity name of the ontology, e.g. `"ALCHN(D)"`
+- `get_prefixes() -> Dict[str, str]` / `set_prefix(prefix: str, namespace: str)` / `remove_prefix(prefix: str)` - Manage prefix -> namespace IRI mappings used by `save()`
 
 **Example:**
 ```python
@@ -115,7 +117,7 @@ onto = NeuralOntology("ontology.owl", "embeddings.pkl")
 ### `RDFLibReasoner` (Recommended)
 
 ```python
-from owlapy.owl_reasoner import RDFLibReasoner
+from owlapy.owl_reasoner_rdflib import RDFLibReasoner
 ```
 
 Pure Python reasoner using SPARQL queries. No circular dependencies, efficient caching.
@@ -167,8 +169,11 @@ stopJVM()
 
 **Additional Methods:**
 - `has_consistent_ontology() -> bool` - Check consistency
-- `is_entailed(axiom: OWLAxiom) -> bool` - Check entailment
-- `get_root_ontology() -> Ontology` - Get underlying ontology with justification support
+- `is_entailed(axiom: OWLAxiom, timeout: int = 1000) -> bool` - Check entailment
+- `get_root_ontology() -> AbstractOWLOntology` - Get the underlying ontology
+- `create_axiom_justifications(axiom, n_max_justifications=10, timeout=1000, save=False) -> List[Set[OWLAxiom]]` - Explain why an axiom is entailed
+- `create_laconic_axiom_justifications(axiom, ...) -> List[Set[OWLAxiom]]` - Same, but each justification is minimized/laconic
+- `infer_axioms_and_save(output_path, output_format=None, inference_types=[...])` - Materialize inferred axioms (e.g. `["InferredClassAssertionAxiomGenerator"]`) and save them
 
 ## Class Expressions
 
@@ -271,21 +276,21 @@ from owlapy.class_expression import (
 )
 ```
 
-#### `OWLObjectMinCardinality(cardinality: int, property, filler=None)`
-Minimum cardinality (≥).
+#### `OWLObjectMinCardinality(cardinality: int, property, filler)`
+Minimum cardinality (≥). `filler` is required -- use `OWLThing` for "any".
 
 ```python
-at_least_two_children = OWLObjectMinCardinality(2, has_child_prop)  # ≥2 hasChild
+at_least_two_children = OWLObjectMinCardinality(2, has_child_prop, OWLThing)  # ≥2 hasChild.⊤
 ```
 
-#### `OWLObjectMaxCardinality(cardinality: int, property, filler=None)`
-Maximum cardinality (≤).
+#### `OWLObjectMaxCardinality(cardinality: int, property, filler)`
+Maximum cardinality (≤). `filler` is required -- use `OWLThing` for "any".
 
 ```python
-at_most_one_spouse = OWLObjectMaxCardinality(1, has_spouse_prop)  # ≤1 hasSpouse
+at_most_one_spouse = OWLObjectMaxCardinality(1, has_spouse_prop, OWLThing)  # ≤1 hasSpouse.⊤
 ```
 
-#### `OWLObjectExactCardinality(cardinality: int, property, filler=None)`
+#### `OWLObjectExactCardinality(cardinality: int, property, filler)`
 Exact cardinality (=).
 
 ```python
@@ -368,11 +373,22 @@ Named individual (instance).
 john = OWLNamedIndividual("http://example.com/onto#John")
 ```
 
+#### `OWLAnonymousIndividual(node_id: str = None)`
+Blank-node individual, identified by a local node ID instead of an IRI. Generates a
+fresh, unused node ID if none is given.
+
+```python
+from owlapy.owl_individual import OWLAnonymousIndividual
+
+anon = OWLAnonymousIndividual()          # auto-generated node id
+anon2 = OWLAnonymousIndividual("_:b0")   # explicit node id
+```
+
 ## Literals
 
 ```python
-from owlapy.owl_literal import OWLLiteral
-from owlapy.owl_datatype import (
+from owlapy.owl_literal import (
+    OWLLiteral,
     IntegerOWLDatatype,
     DoubleOWLDatatype,
     BooleanOWLDatatype,
@@ -382,8 +398,8 @@ from owlapy.owl_datatype import (
 )
 ```
 
-#### `OWLLiteral(value, datatype=StringOWLDatatype)`
-Literal value.
+#### `OWLLiteral(value, type_: OWLDatatype = None)`
+Literal value. `type_` is inferred from `value`'s Python type if omitted.
 
 ```python
 age = OWLLiteral(25, IntegerOWLDatatype)
@@ -393,6 +409,17 @@ is_student = OWLLiteral(True, BooleanOWLDatatype)
 ```
 
 ## Axioms
+
+Every `OWLAxiom` has a `.signature() -> Set[OWLEntity]` method returning the named
+classes/object properties/data properties/individuals/datatypes it references (class
+expressions and data ranges have the same method). Coverage is limited to declaration,
+class/property assertions, sub-class-of, equivalent/disjoint classes, and property
+domain/range axioms; other axiom types raise `NotImplementedError` (tracked in #231).
+
+```python
+axiom = OWLSubClassOfAxiom(student, person)
+axiom.signature()  # {student, person}
+```
 
 ### Class Axioms
 
@@ -491,15 +518,15 @@ Create empty ontology.
 onto = create_ontology("http://example.com/my-ontology")
 ```
 
-#### `csv_to_rdf_kg(csv_file, output_file, namespace, class_name, delimiter=',')`
-Convert CSV to RDF knowledge graph.
+#### `csv_to_rdf_kg(path_csv, path_kg, namespace)`
+Convert CSV to RDF knowledge graph. Each row becomes an individual; each column becomes
+a data property named after the column header, scoped under `namespace`.
 
 ```python
 csv_to_rdf_kg(
-    csv_file="data.csv",
-    output_file="kg.owl",
+    path_csv="data.csv",
+    path_kg="kg.owl",
     namespace="http://example.com/data#",
-    class_name="DataPoint"
 )
 ```
 
@@ -578,8 +605,10 @@ similarity = f1_set_similarity(instances1, instances2)
 
 ## AGenKG (LLM-based Generation)
 
+Requires `dspy` (`pip install owlapy[agentic]`).
+
 ```python
-from owlapy.agen_kg import AGenKG, DomainGraphExtractor, OpenGraphExtractor
+from owlapy.agen_kg import AGenKG
 ```
 
 ### `AGenKG`
@@ -590,13 +619,21 @@ Generate ontologies from text using LLMs.
 ```python
 AGenKG(
     model: str = "gpt-4o",
-    api_key: str = None,
-    api_base: str = "https://api.openai.com/v1"
+    api_key: str = "<YOUR_GITHUB_PAT>",
+    api_base: str = "https://models.github.ai/inference",
+    temperature: float = 0.1,
+    seed: int = 42,
+    cache: bool = False,
+    enable_logging: bool = False,
+    max_tokens: int = 4000,
 )
 ```
 
+Any OpenAI-compatible endpoint works (OpenAI, Azure OpenAI, GitHub Models, Ollama, vLLM) -- just swap `api_base`/`model`.
+
 **Methods:**
-- `generate_ontology(text: str, ontology_type: str = "domain", save_path: str = None) -> SyncOntology`
+
+- `generate_ontology(text, ontology_type: str = "domain", query=None, **kwargs) -> Ontology` -- `save_path` (must end in `.owl`) is a supported `**kwargs` entry
 
 **Example:**
 ```python
@@ -613,22 +650,20 @@ ontology = agent.generate_ontology(
 )
 ```
 
-### `DomainGraphExtractor`
+### `DomainGraphExtractor` / `OpenGraphExtractor`
 
-Extract domain-specific knowledge graph.
-
-```python
-extractor = DomainGraphExtractor(model="gpt-4o", api_key="key")
-kg = extractor.extract(text="Medical records...")
-```
-
-### `OpenGraphExtractor`
-
-Extract open-domain knowledge graph.
+Lower-level building blocks that `AGenKG` wraps internally (`ontology_type="domain"` vs
+`"open"`) -- construct one directly only if you need to bypass `AGenKG`. They reuse
+whichever LLM was last configured via `dspy.configure(lm=...)` (which `AGenKG.__init__`
+does for you), rather than taking their own `model`/`api_key`.
 
 ```python
-extractor = OpenGraphExtractor(model="gpt-4o", api_key="key")
-kg = extractor.extract(text="General text...")
+from owlapy.agen_kg.graph_extracting_models import DomainGraphExtractor, OpenGraphExtractor
+
+AGenKG(model="gpt-4o", api_key="your-key")  # configures dspy's LM as a side effect
+
+extractor = DomainGraphExtractor(enable_logging=True)
+kg = extractor.generate_ontology(text="Medical records...", ontology_type="domain")
 ```
 
 ## IRI
@@ -694,7 +729,8 @@ rule = Rule(
 from owlapy.owl_ontology import SyncOntology, Ontology, NeuralOntology
 
 # Reasoners
-from owlapy.owl_reasoner import RDFLibReasoner, StructuralReasoner, SyncReasoner
+from owlapy.owl_reasoner_rdflib import RDFLibReasoner
+from owlapy.owl_reasoner import StructuralReasoner, SyncReasoner
 
 # Class Expressions
 from owlapy.class_expression import (
@@ -710,8 +746,7 @@ from owlapy.owl_property import OWLObjectProperty, OWLDataProperty, OWLObjectInv
 
 # Individuals & Literals
 from owlapy.owl_individual import OWLNamedIndividual
-from owlapy.owl_literal import OWLLiteral
-from owlapy.owl_datatype import IntegerOWLDatatype, DoubleOWLDatatype, StringOWLDatatype
+from owlapy.owl_literal import OWLLiteral, IntegerOWLDatatype, DoubleOWLDatatype, StringOWLDatatype
 
 # Axioms
 from owlapy.owl_axiom import (

--- a/markdown_docs/README.md
+++ b/markdown_docs/README.md
@@ -14,17 +14,21 @@ owlapy is a production-ready Python framework for OWL ontology engineering, know
 ### Core Concepts
 - [02_core_concepts.md](02_core_concepts.md) - OWL fundamentals, ontologies, reasoners, class expressions
 - [03_ontology_management.md](03_ontology_management.md) - Creating, loading, saving, and modifying ontologies
-- [04_class_expressions.md](04_class_expressions.md) - Building and using OWL class expressions
+
+  Building and using OWL class expressions specifically: see "Class Expressions" in
+  [02_core_concepts.md](02_core_concepts.md#3-class-expressions) and
+  [09_api_reference.md](09_api_reference.md#class-expressions).
 
 ### Advanced Features
 - [05_reasoning.md](05_reasoning.md) - Semantic reasoning with StructuralReasoner, RDFLibReasoner, and SyncReasoner
-- [06_syntax_conversion.md](06_syntax_conversion.md) - Converting between DL syntax, Manchester syntax, and SPARQL
-- [07_knowledge_graph_generation.md](07_knowledge_graph_generation.md) - LLM-based ontology generation with AGenKG
+
+  Syntax conversion (DL / Manchester / SPARQL) and LLM-based KG generation (AGenKG) don't
+  have dedicated deep-dive docs yet -- see "Syntax Conversion" and "AGenKG" in
+  [09_api_reference.md](09_api_reference.md) for what's covered so far.
 
 ### Practical Guides
 - [08_common_patterns.md](08_common_patterns.md) - Common use cases, patterns, and anti-patterns
 - [09_api_reference.md](09_api_reference.md) - Quick reference for all key classes and functions
-- [10_migration_guide.md](10_migration_guide.md) - Migrating from other OWL libraries and upgrading owlapy
 
 ## Key Features
 
@@ -38,7 +42,7 @@ owlapy is a production-ready Python framework for OWL ontology engineering, know
 
 ```python
 from owlapy.owl_ontology import SyncOntology
-from owlapy.owl_reasoner import RDFLibReasoner
+from owlapy.owl_reasoner_rdflib import RDFLibReasoner
 from owlapy.class_expression import OWLClass
 
 # Load ontology


### PR DESCRIPTION
## Summary

While documenting the new prefix-management feature (#229 / #233) I audited the rest of `markdown_docs/` and found it had never actually been verified against the real API. Every example in this PR was checked against the current source and, where feasible, executed end-to-end against real test ontologies (`KGs/Family/...`).

Confirmed bugs fixed (most repeated across several files):

- `RDFLibReasoner` imported from `owlapy.owl_reasoner` (wrong module) instead of `owlapy.owl_reasoner_rdflib` -- in every file that mentions it (it's presented as the recommended reasoner)
- `IntegerOWLDatatype`/`StringOWLDatatype`/etc. imported from `owlapy.owl_datatype` (only has the `OWLDatatype` base class) instead of `owlapy.owl_literal`
- `OWLObjectMinCardinality`/`MaxCardinality` called with only 2 args -- `filler` is a required positional argument, not optional
- `SyncOntology.save(..., format=...)` -- the real parameter is `document_format`
- `csv_to_rdf_kg(csv_file=, output_file=, class_name=...)` -- none of these parameters exist; the real ones are `path_csv`, `path_kg`, `namespace`
- `OWLSubPropertyChainOfAxiom`, which doesn't exist -> `OWLSubPropertyChainAxiom`
- `reasoner.get_root_ontology().get_justifications(...)`, which doesn't exist -> `reasoner.create_axiom_justifications(...)`
- `infer_axioms_and_save()` documented as a free function -- it's a `SyncReasoner` method
- `equivalent_classes()`/`disjoint_classes()` used as a two-class boolean check -- they take one class expression and return everything equivalent/disjoint to it
- AGenKG's `DomainGraphExtractor`/`OpenGraphExtractor`: wrong import path, fabricated `model`/`api_key` constructor args, nonexistent `.extract()` method; `AGenKG`'s documented `api_base` default didn't match the real default

Added coverage for shipped-but-undocumented features:

- `SyncOntology` prefix management (`get_prefixes`/`set_prefix`/`remove_prefix`, #229)
- `get_dl_expressivity()`
- `axiom.signature()` / `class_expression.signature()`
- `OWLAnonymousIndividual`
- the `timeout=` parameter on reasoner methods (`instances`, `is_entailed`, `create_axiom_justifications`)

Also repointed `README.md`'s links to `04_class_expressions.md`, `06_syntax_conversion.md`, `07_knowledge_graph_generation.md`, and `10_migration_guide.md` -- none of which have ever existed in this repo (checked git history) -- at the sections of `02_core_concepts.md`/`09_api_reference.md` that currently cover that material. Writing those 4 files from scratch is out of scope for this cleanup.

## Test plan

- [x] Every `from owlapy... import ...` statement across `markdown_docs/*.md` verified to resolve via an automated script (`importlib` + `hasattr`)
- [x] Ran the fixed ontology-management, reasoning, and cardinality-restriction examples end-to-end against `KGs/Family/father.owl` and `KGs/Family/family-benchmark_rich_background.owl`
- [x] Verified `AGenKG`/`DomainGraphExtractor`/`OpenGraphExtractor` construct correctly with the corrected import paths and constructor args (no live LLM call needed for this)
- [x] No source code changes -- documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)