### PR TITLE
chore: finish Phase 0 quick wins from IMPROVEMENTS.md

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,15 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Check version sync (__init__.py vs setup.py)
+        run: |
+          INIT_VERSION=$(python -c "import re; print(re.search(r\"__version__ = '([^']+)'\", open('owlapy/__init__.py').read()).group(1))")
+          SETUP_VERSION=$(python -c "import re; print(re.search(r'version=\"([^\"]+)\"', open('setup.py').read()).group(1))")
+          if [ "$INIT_VERSION" != "$SETUP_VERSION" ]; then
+            echo "Version mismatch: owlapy/__init__.py has $INIT_VERSION, setup.py has $SETUP_VERSION"
+            exit 1
+          fi
+          echo "Versions in sync: $INIT_VERSION"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- CI step in `.github/workflows/test.yml` that fails the build if `owlapy/__init__.py`'s `__version__` and `setup.py`'s `version=` disagree, enforcing the dual-source-of-truth documented in `CLAUDE.md` (IMPROVEMENTS.md 5.2)
 - The ontology generation pipeline now supports (#219):
   - `rdfs:label` annotations, deterministically computed from entity IRIs
   - `rdfs:comment` annotations, generated via LLM
@@ -27,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `agen_kg` LLM pipeline now also logs through the `logging` module instead of `print()`. The existing `enable_logging` flag keeps its meaning: when set, progress messages are emitted via per-module loggers under `owlapy.agen_kg` and a console handler is attached so output stays visible without extra configuration; `except`-block diagnostics now use `logger.exception(...)` and include tracebacks. Host applications that configure logging themselves can control verbosity via the `owlapy` logger hierarchy.
 - Added `IMPROVEMENTS.md`, a prioritized plan of readability, performance, documentation, and feature improvements for the library
 - Ignored generated/scratch artifacts (`demo.owl`, `inferred_axioms_ontology.owl`, `iris_dataset.csv`, `tests/saved_formats/`) that examples and tests write to the repo root
+- `class_expression/restriction.py`'s 10 repeated `# @TODO: CD: property shows the in-built function` comments consolidated into a single module-level docstring note; removed a stray, obsolete `# TODO: XXX` in `owl_axiom.py` whose actual gap is already documented in `signature()`'s docstring (IMPROVEMENTS.md 1.1)
 
 ### Fixed
 - `StructuralReasoner.object_property_values()` no longer crashes with `AttributeError: 'Or' object has no attribute 'iri'` on ontologies that illegally pun an entity as multiple property types (e.g. `KGs/Biopax/biopax.owl`, where `glycolysis#DELTA-G` is declared as both `owl:ObjectProperty` and `owl:AnnotationProperty`). owlready2's load-time punning repair can make values of unrelated properties come back as internal class-expression nodes (`owlready2.Or`) instead of individuals; these are now skipped with a warning (emitted once per property) that points at the punning as the root cause, instead of crashing or silently dropping values (#242, supersedes #236)

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -21,19 +21,27 @@ effort estimates, and sequencing.
 > `CHANGELOG.md` for the record (e.g. the print-to-logging migration, done for
 > the core library and `agen_kg` in the 1.6.6 cycle).
 
-### 1.1 Burn down the `TODO`/`FIXME` backlog — 63 markers
-- **Where:** e.g. `class_expression/restriction.py` (13 `@TODO: CD:` notes,
-  several asking to convert methods to `@property`), `render.py:323/517/544`,
-  `owl_hierarchy.py:32/124` (unimplemented equivalence-set handling),
-  `owl_ontology.py` (multiple `@TODO: CD:` on ABox/TBox retrieval),
-  `parser.py:411/756` (decimal-vs-float shortcut).
+### 1.1 Burn down the `TODO`/`FIXME` backlog — 52 markers remaining (was 63)
+- **Status:** First triage pass done. `class_expression/restriction.py`'s 10
+  repeated "property shows the in-built function" notes were consolidated into
+  a single module-level docstring note (the design decision — `property` as a
+  parameter name intentionally shadows the builtin — only needs stating once).
+  One truly obsolete marker (`owl_axiom.py`'s trailing `# TODO: XXX` after
+  `signature()`, whose actual gap is already documented in that method's
+  docstring with a link to #231) was deleted. The remaining ~52 markers were
+  reviewed and are legitimate — either real, non-trivial correctness/design
+  questions (`render.py:325/519/546`, `owl_hierarchy.py:32/124`,
+  `owl_class.py:56-57`, `nary_boolean_expression.py:19`,
+  `owl_ontology.py`'s ABox/TBox `NotImplementedError` stubs and owlready2
+  bug notes) or already tracked elsewhere in this plan (4.1, 4.2).
+- **Where:** e.g. `owl_ontology.py` (multiple `@TODO: CD:` on ABox/TBox
+  retrieval), `parser.py:411/756` (decimal-vs-float shortcut, tracked in 3.3).
 - **Why:** Author-initialled `CD:`/`AB:` comments are effectively a hidden issue
-  tracker. They hint at real correctness gaps (e.g. `render.py:544` "Can we
+  tracker. They hint at real correctness gaps (e.g. `render.py:546` "Can we
   assume equiv size will be 2?", `owl_hierarchy.py` unhandled eq-sets).
-- **Approach:** Triage into (a) trivial cleanups (do now), (b) real bugs → file
-  GitHub issues, (c) obsolete → delete. Start with `restriction.py`'s repeated
-  "property shows the in-built function" notes, which are a single consistent
-  design decision that can be documented once instead of 13 times.
+- **Approach:** Remaining work is (b) real bugs → file GitHub issues where
+  worth tracking independently, most are small enough to stay as in-code
+  markers for now.
 
 ### 1.2 Decompose the largest modules
 - **Where:** `owl_reasoner.py` (3302 LOC, holds both `StructuralReasoner` and
@@ -215,11 +223,14 @@ effort estimates, and sequencing.
   `iris_dataset.csv`, and any test-generated `tests/saved_formats/` output. Point
   test fixtures at the scratchpad/`tmp` rather than the repo root.
 
-### 5.2 Enforce version sync in CI
+### 5.2 Enforce version sync in CI — ✅ *done*
+- **Status:** `.github/workflows/test.yml` now has a "Check version sync" step
+  (runs before dependency install, so it fails fast) that parses
+  `owlapy/__init__.py`'s `__version__` and `setup.py`'s `version=` and fails
+  the build if they disagree. The README badge is not covered — it's static
+  text, not worth a CI check on its own.
 - **Where:** `owlapy/__init__.py` + `setup.py` (CLAUDE.md documents the
   dual-source-of-truth).
-- **Approach:** Tiny CI step (or pre-commit hook) asserting the two versions
-  match, plus optionally the README badge. Prevents the drift seen in 3.2.
 
 ### 5.3 Consider tightening lint/type gates over time
 - **Where:** `pyproject.toml` — ruff selects only `E/W/F/I`; mypy has
@@ -234,13 +245,15 @@ effort estimates, and sequencing.
 
 Phased so each phase is independently shippable and low-risk first.
 
-### Phase 0 — Quick wins (hours, no behavior change)
-1. Fix README mojibake headers (3.1).
-2. Sync version badges + add CI version-sync check (3.2, 5.2).
-3. Remove/ignore stray root artifacts (5.1).
-4. TODO triage pass: delete obsolete, convert real bugs to issues (1.1 part a).
+### Phase 0 — Quick wins ✅ *shipped*
+1. ✅ Fix README mojibake headers (3.1).
+2. ✅ Sync version badges + add CI version-sync check (3.2, 5.2).
+3. ✅ Remove/ignore stray root artifacts (5.1).
+4. ✅ TODO triage pass: consolidated `restriction.py`'s repeated notes, deleted
+   the one obsolete marker found, reviewed the rest (1.1) — see 1.1 for what's
+   left open (real, non-trivial items, not quick wins).
 
-*Deliverable:* clean tree, accurate metadata, an issue backlog.
+*Deliverable:* clean tree, accurate metadata, reviewed TODO backlog.
 
 ### Phase 1 — Logging migration ✅ *shipped* + exception tightening
 5. ✅ Per-module loggers now cover the core library and `agen_kg`; recorded in

--- a/owlapy/class_expression/restriction.py
+++ b/owlapy/class_expression/restriction.py
@@ -1,4 +1,10 @@
-"""OWL Restrictions"""
+"""OWL Restrictions.
+
+Note: several restriction constructors below take a parameter named ``property``,
+which shadows the Python built-in ``property`` decorator within that scope. This
+is intentional -- it mirrors the OWL API's terminology (`getProperty()`) and the
+`get_property()` accessor defined on `OWLRestriction` -- not an oversight.
+"""
 from abc import ABCMeta, abstractmethod
 from datetime import date, datetime
 from typing import Final, Generic, Iterable, Sequence, TypeVar, Union
@@ -151,7 +157,6 @@ class OWLObjectCardinalityRestriction(OWLCardinalityRestriction[OWLClassExpressi
     __slots__ = ()
 
     _property: OWLObjectPropertyExpression
-    # @TODO: CD: property shows the in-built function
 
     @abstractmethod
     def __init__(self, cardinality: int, property: OWLObjectPropertyExpression, filler: OWLClassExpression):
@@ -294,7 +299,6 @@ class OWLObjectAllValuesFrom(OWLQuantifiedObjectRestriction):
     individuals that are instances of CE. (https://www.w3.org/TR/owl2-syntax/#Universal_Quantification)"""
     __slots__ = '_property', '_filler'
     type_index: Final = 3006
-    # @TODO: CD: property shows the in-built function
     def __init__(self, property: OWLObjectPropertyExpression, filler: OWLClassExpression):
         super().__init__(filler)
         self._property = property
@@ -365,7 +369,6 @@ class OWLObjectHasValue(OWLHasValueRestriction[OWLIndividual], OWLObjectRestrict
 
     _property: OWLObjectPropertyExpression
     _v: OWLIndividual
-    # @TODO: CD: property shows the in-built function
     def __init__(self, property: OWLObjectPropertyExpression, individual: OWLIndividual):
         """
         Args:
@@ -497,7 +500,6 @@ class OWLDataCardinalityRestriction(OWLCardinalityRestriction[OWLDataRange],
     __slots__ = ()
 
     _property: OWLDataPropertyExpression
-    # @TODO: CD: property shows the in-built function
 
     @abstractmethod
     def __init__(self, cardinality: int, property: OWLDataPropertyExpression, filler: OWLDataRange):
@@ -533,7 +535,6 @@ class OWLDataMinCardinality(OWLDataCardinalityRestriction):
     __slots__ = '_cardinality', '_filler', '_property'
 
     type_index: Final = 3015
-    # @TODO: CD: property shows the in-built function
 
     def __init__(self, cardinality: int, property: OWLDataPropertyExpression, filler: OWLDataRange):
         """
@@ -557,7 +558,6 @@ class OWLDataMaxCardinality(OWLDataCardinalityRestriction):
     __slots__ = '_cardinality', '_filler', '_property'
 
     type_index: Final = 3017
-    # @TODO: CD: property shows the in-built function
 
     def __init__(self, cardinality: int, property: OWLDataPropertyExpression, filler: OWLDataRange):
         """
@@ -581,7 +581,6 @@ class OWLDataExactCardinality(OWLDataCardinalityRestriction):
     __slots__ = '_cardinality', '_filler', '_property'
 
     type_index: Final = 3016
-    # @TODO: CD: property shows the in-built function
 
     def __init__(self, cardinality: int, property: OWLDataPropertyExpression, filler: OWLDataRange):
         """
@@ -618,7 +617,6 @@ class OWLDataSomeValuesFrom(OWLQuantifiedDataRestriction):
     type_index: Final = 3012
 
     _property: OWLDataPropertyExpression
-    # @TODO: CD: property shows the in-built function
 
     def __init__(self, property: OWLDataPropertyExpression, filler: OWLDataRange):
         """Gets an OWLDataSomeValuesFrom restriction.
@@ -663,7 +661,6 @@ class OWLDataAllValuesFrom(OWLQuantifiedDataRestriction):
     type_index: Final = 3013
 
     _property: OWLDataPropertyExpression
-    # @TODO:CD:property shows the in-built function
 
     def __init__(self, property: OWLDataPropertyExpression, filler: OWLDataRange):
         """Gets an OWLDataAllValuesFrom restriction.
@@ -710,7 +707,6 @@ class OWLDataHasValue(OWLHasValueRestriction[OWLLiteral], OWLDataRestriction):
     type_index: Final = 3014
 
     _property: OWLDataPropertyExpression
-    # @TODO: CD: property shows the in-built function
 
     def __init__(self, property: OWLDataPropertyExpression, value: OWLLiteral):
         """Gets an OWLDataHasValue restriction.

--- a/owlapy/owl_axiom.py
+++ b/owlapy/owl_axiom.py
@@ -58,7 +58,6 @@ class OWLAxiom(OWLObject, metaclass=ABCMeta):
         """
         from owlapy.utils import SignatureExtractor
         return SignatureExtractor().get_signature(self)
-    # TODO: XXX
 
 
 class OWLLogicalAxiom(OWLAxiom, metaclass=ABCMeta):


### PR DESCRIPTION
## Summary
- Adds a CI step (`.github/workflows/test.yml`) that fails the build if `owlapy/__init__.py`'s `__version__` and `setup.py`'s `version=` disagree — closes the CI half of IMPROVEMENTS.md 5.2 (badge sync itself already shipped in 8a1e6a3).
- TODO/FIXME triage pass (IMPROVEMENTS.md 1.1): consolidates `class_expression/restriction.py`'s 10 repeated `# @TODO: CD: property shows the in-built function` notes into a single module docstring note, and deletes one obsolete marker in `owl_axiom.py` whose gap is already documented in `signature()`'s docstring (with a link to #231). Reviewed the remaining ~52 markers — they're legitimate, non-trivial design/correctness questions, left as-is (see updated IMPROVEMENTS.md 1.1 for the breakdown).
- Updates `IMPROVEMENTS.md` and `CHANGELOG.md` to record what shipped and re-scope Phase 0 as complete.

No behavior changes to the public API.

## Test plan
- [x] `ruff check owlapy --line-length=200` passes
- [x] `PYTHONPATH=. pytest` on class-expression/axiom test files (67 passed; unrelated `FileNotFoundError`s are from the KGs fixture not being downloaded in this environment, not from these changes)
- [x] Verified `OWLObjectSomeValuesFrom`/`get_property()` still work after the restriction.py comment consolidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjFUR5dk8JEk7h8MrqH3Eo