### PR TITLE
fix: OWLLiteral accepts tuple values for GYearMonth/GMonthDay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Guarded `rdfs:comment` batch generation against LLM call failures, so a single failed batch no longer aborts the whole ontology generation pipeline (#223)
 - Fixed an infinite loop in `TextChunker`'s fixed-size chunking strategy that could occur with `overlap > 0` once the cursor reached the end of the text (#224)
 - `map_datarange` now degrades gracefully to the top datatype instead of raising `ValueError` on unrecognized data-range fillers (e.g. `owl:Thing` used where a datatype is expected), so a single malformed axiom no longer aborts hierarchy traversal in `super_classes`/`sub_classes`/`object_property_ranges` (#225, #226)
+- `OWLLiteral((year, month), GYearMonthOWLDatatype)` / `OWLLiteral((month, day), GMonthDayOWLDatatype)` no longer always raise `ValueError` on tuple input; `_OWLGDatesInterface.__init__` was unconditionally falling through to its string-parsing branch's `else: raise ValueError(...)` for any non-string value, including tuples it had just validated as length-2. Only string input (e.g. `"2020-05"`) worked before this fix. (#237)
 
 ## [1.6.5] - 2026-05-26
 

--- a/owlapy/owl_literal.py
+++ b/owlapy/owl_literal.py
@@ -841,7 +841,7 @@ class _OWLGDatesInterface(_OWLLiteralBasicsInterface):
         if isinstance(value, tuple) or type_ in [GYearMonthOWLDatatype, GMonthDayOWLDatatype]:
             if isinstance(value, tuple):
                 assert len(value) == 2
-            if isinstance(value, str):
+            elif isinstance(value, str):
                 # expected string input examples: "2001-10", "--11-15"
                 splits = value.lstrip("-").split("-")
                 value = (int(splits[0]), int(splits[1][:2]))

--- a/tests/test_owl_literal.py
+++ b/tests/test_owl_literal.py
@@ -425,19 +425,22 @@ def test_gyearmonth_from_string():
     assert lit.parse_gyearmonth() == (2020, 5)
 
 
-def test_gyearmonth_rejects_tuple_value_directly():
-    # NOTE: despite the type hint `_v: Union[tuple, int]` and the leading
-    # `if isinstance(value, tuple): assert len(value) == 2` check, the surrounding
-    # `if isinstance(value, str): ... else: raise ValueError(...)` is unconditional,
-    # so passing an actual tuple currently always raises -- only string input works.
-    with pytest.raises(ValueError):
-        OWLLiteral((2020, 5), GYearMonthOWLDatatype)
+def test_gyearmonth_accepts_tuple_value_directly():
+    lit = OWLLiteral((2020, 5), GYearMonthOWLDatatype)
+    assert lit.is_gyearmonth()
+    assert lit.parse_gyearmonth() == (2020, 5)
 
 
 def test_gmonthday_from_string():
     lit_from_str = OWLLiteral("--05-20", GMonthDayOWLDatatype)
     assert lit_from_str.is_gmonthday()
     assert lit_from_str.parse_gmonthday() == (5, 20)
+
+
+def test_gmonthday_accepts_tuple_value_directly():
+    lit = OWLLiteral((5, 20), GMonthDayOWLDatatype)
+    assert lit.is_gmonthday()
+    assert lit.parse_gmonthday() == (5, 20)
 
 
 def test_gyear_gmonth_gday_from_int_and_string():


### PR DESCRIPTION
## Summary
- Fixes bug 1 from #237: `OWLLiteral((year, month), GYearMonthOWLDatatype)` / `OWLLiteral((month, day), GMonthDayOWLDatatype)` always raised `ValueError`. `_OWLGDatesInterface.__init__` validated tuple length (`assert len(value) == 2`) but then unconditionally checked `if isinstance(value, str): ... else: raise ValueError(...)`, so any non-string value — including a tuple that had just passed validation — hit the `else` branch. Only string input (e.g. `"2020-05"`) actually worked.
- Fix: made the string-parsing branch an `elif`, so a validated tuple falls through unchanged instead of hitting the `else: raise`.
- Updated `tests/test_owl_literal.py::test_gyearmonth_rejects_tuple_value_directly` (which documented the bug) into `test_gyearmonth_accepts_tuple_value_directly`, asserting the tuple is now accepted and round-trips correctly; added the equivalent test for `GMonthDayOWLDatatype`.
- Added a `CHANGELOG.md` entry under `[Unreleased] / Fixed`.

## Test plan
- [x] `pytest tests/test_owl_literal.py -p no:warnings -q` — 68 passed
- [x] `ruff check owlapy/owl_literal.py tests/test_owl_literal.py --line-length=200` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)