### PR TITLE
test: regression coverage + changelog for #271/#272 type checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Python-side type checks across OWL construct constructors (`owlapy.owl_axiom`, `owlapy.class_expression`, `owlapy.owl_property`, `owlapy.owl_individual`, `owlapy.owl_datatype`, `owlapy.owl_literal`, `owlapy.namespaces`): constructing an OWL axiom/class expression/entity with an argument of the wrong type (e.g. an `OWLSubClassOfAxiom` given object properties instead of class expressions) now raises a clear `TypeError`/`ValueError` immediately, instead of succeeding silently and only failing later -- as an opaque Java exception -- once the construct is used with a JVM-backed ontology (#271, #272)
+- Additional regression tests for the `owlapy.owl_axiom` type checks above, covering `OWLSubClassOfAxiom`, `OWLClassAssertionAxiom`, `OWLEquivalentClassesAxiom`, `OWLObjectPropertyAssertionAxiom`, `OWLObjectPropertyDomainAxiom`, `OWLFunctionalObjectPropertyAxiom`, and `OWLDeclarationAxiom` (#271)
+
 ## [1.6.6] - 2026-08-05
 
 ### Added

--- a/tests/test_owl_axiom_extra_coverage.py
+++ b/tests/test_owl_axiom_extra_coverage.py
@@ -388,3 +388,44 @@ def test_sub_property_chain_axiom_eq_false_for_different_type():
     assert (axiom == "not an axiom") is False
     assert axiom == OWLSubPropertyChainAxiom(chain, obj_prop("hasGrandparent"))
     assert list(axiom.get_property_chain()) == chain
+
+
+# ---------------------------------------------------------------------------
+# Python-side type checks (owlapy#271): constructing an axiom with an argument
+# of the wrong OWL construct type must fail immediately with a clear Python
+# error, not silently succeed and only blow up once the JVM gets involved.
+# ---------------------------------------------------------------------------
+
+def test_sub_class_of_axiom_rejects_non_class_expression():
+    with pytest.raises(TypeError):
+        OWLSubClassOfAxiom(obj_prop("p1"), obj_prop("p2"))
+
+
+def test_class_assertion_axiom_rejects_swapped_arguments():
+    with pytest.raises(TypeError):
+        OWLClassAssertionAxiom(cls("A"), ind("alice"))
+
+
+def test_equivalent_classes_axiom_rejects_non_class_expression():
+    with pytest.raises(TypeError):
+        OWLEquivalentClassesAxiom([cls("A"), obj_prop("p")])
+
+
+def test_object_property_assertion_axiom_rejects_data_property():
+    with pytest.raises(TypeError):
+        OWLObjectPropertyAssertionAxiom(ind("alice"), data_prop("age"), ind("bob"))
+
+
+def test_object_property_domain_axiom_rejects_data_property():
+    with pytest.raises(TypeError):
+        OWLObjectPropertyDomainAxiom(data_prop("age"), cls("A"))
+
+
+def test_functional_object_property_axiom_rejects_data_property():
+    with pytest.raises(TypeError):
+        OWLFunctionalObjectPropertyAxiom(data_prop("age"))
+
+
+def test_declaration_axiom_rejects_non_entity():
+    with pytest.raises(TypeError):
+        OWLDeclarationAxiom("not an entity")


### PR DESCRIPTION
## Summary
- #272 (merged) implements the Python-side type checks requested in #271 across `OWLAxiom`/class-expression/entity constructors, but shipped without test coverage for `owl_axiom.py` itself or a `CHANGELOG.md` entry.
- Adds targeted regression tests exercising the `TypeError` paths for a representative set of axiom constructors: `OWLSubClassOfAxiom`, `OWLClassAssertionAxiom`, `OWLEquivalentClassesAxiom`, `OWLObjectPropertyAssertionAxiom`, `OWLObjectPropertyDomainAxiom`, `OWLFunctionalObjectPropertyAxiom`, `OWLDeclarationAxiom`.
- Records the change in `CHANGELOG.md`'s `[Unreleased]` section, per `CLAUDE.md` convention.

## Test plan
- [x] `ruff check owlapy tests/test_owl_axiom_extra_coverage.py --line-length=200`
- [x] `PYTHONPATH=. pytest tests/test_owl_axiom_extra_coverage.py -p no:warnings -q` (40 passed)
- [x] `PYTHONPATH=. pytest --ignore=tests/test_z_do_last_ebr_retrieval.py -p no:warnings -q` (1307 passed, 23 skipped, 1 pre-existing unrelated flaky timing failure in `test_rdflib_reasoner_regression.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)